### PR TITLE
Bugfix with listen server

### DIFF
--- a/Server/Core/Server.cs
+++ b/Server/Core/Server.cs
@@ -207,10 +207,13 @@ namespace xServer.Core
         {
             KeepAlive keepAlive = (KeepAlive)state;
 
-            if (_keepAlives.Contains(keepAlive))
+            if (_keepAlives != null)
             {
-                keepAlive.Client.Disconnect();
-                _keepAlives.Remove(keepAlive);
+                if (_keepAlives.Contains(keepAlive))
+                {
+                    keepAlive.Client.Disconnect();
+                    _keepAlives.Remove(keepAlive);
+                }
             }
         }
 


### PR DESCRIPTION
Added null check for keepalive timer callback to prevent server
application from crashing when stopping the listen server when client(s)
connect and initiate the keepalive timer