### PR TITLE
Fixed issue with the Remote Desktop

### DIFF
--- a/Client/Core/ProtoBuf/Meta/ValueMember.cs
+++ b/Client/Core/ProtoBuf/Meta/ValueMember.cs
@@ -132,10 +132,9 @@ namespace ProtoBuf.Meta
         }
         private static object ParseDefaultValue(Type type, object value)
         {
-            {
-                Type tmp = Helpers.GetUnderlyingType(type);
-                if (tmp != null) type = tmp;
-            }
+            Type tmp = Helpers.GetUnderlyingType(type);
+            if (tmp != null) type = tmp;
+            
             if (value is string)
             {
                 string s = (string)value;

--- a/Server/Core/ProtoBuf/Meta/ValueMember.cs
+++ b/Server/Core/ProtoBuf/Meta/ValueMember.cs
@@ -132,10 +132,9 @@ namespace ProtoBuf.Meta
         }
         private static object ParseDefaultValue(Type type, object value)
         {
-            {
-                Type tmp = Helpers.GetUnderlyingType(type);
-                if (tmp != null) type = tmp;
-            }
+            Type tmp = Helpers.GetUnderlyingType(type);
+            if (tmp != null) type = tmp;
+            
             if (value is string)
             {
                 string s = (string)value;

--- a/Server/Forms/FrmRemoteDesktop.cs
+++ b/Server/Forms/FrmRemoteDesktop.cs
@@ -54,12 +54,14 @@ namespace xServer.Forms
                         if (_connectClient.Value.LastDesktopSeen)
                         {
                             int Quality = 1;
+                            int SelectedMonitorIndex = 0;
                             this.Invoke((MethodInvoker)delegate
                             {
                                 Quality = barQuality.Value;
+                                SelectedMonitorIndex = cbMonitors.SelectedIndex;
                             });
 
-                            new Core.Packets.ServerPackets.Desktop(Quality, cbMonitors.SelectedIndex).Execute(_connectClient);
+                            new Core.Packets.ServerPackets.Desktop(Quality, SelectedMonitorIndex).Execute(_connectClient);
                             _connectClient.Value.LastDesktopSeen = false;
                         }
                     }


### PR DESCRIPTION
Fixed an issue where Remote Desktop would not work (threw infinite
InvalidOperationExceptions) because cbMonitors.SelectedIndex was trying
to be accessed on a different thread.
Moved code that gets the SelectedIndex inside the MethodInvoker.