### PR TITLE
Bugfix with Remote Desktop

### DIFF
--- a/Client/Core/Client.cs
+++ b/Client/Core/Client.cs
@@ -304,6 +304,8 @@ namespace xClient.Core
                 _writeOffset = 0;
                 _readableDataLen = 0;
                 _payloadLen = 0;
+
+                Core.Commands.CommandHandler.StreamCodec = null;
             }
         }
 


### PR DESCRIPTION
Fixed a bug where after using Remote Desktop and client
disconnection/reconnection, the server wasn't able to run Remote Desktop
again.  I believe there is an issue with the buffer/flow in the
UnsafeStreamCodec class however I wasn't able to pinpoint it.  Setting
this object to null allows a new object to be created when running
Remote Desktop with a fresh buffer.