### PR TITLE
Bugfix #2 with Remote Desktop

### DIFF
--- a/Server/Core/Commands/CommandHandler.cs
+++ b/Server/Core/Commands/CommandHandler.cs
@@ -125,10 +125,16 @@ namespace xServer.Core.Commands
 					Bitmap newScreen = client.Value.StreamCodec.DecodeData(ms);
 
 					client.Value.LastDesktop = newScreen;
-					client.Value.FrmRdp.Invoke((MethodInvoker)delegate
-					{
-						client.Value.FrmRdp.picDesktop.Image = (Bitmap)newScreen.Clone();
-					});
+
+                    try
+                    {
+                        client.Value.FrmRdp.Invoke((MethodInvoker)delegate
+                        {
+                            client.Value.FrmRdp.picDesktop.Image = (Bitmap)newScreen.Clone();
+                        });
+                    }
+                    catch
+                    { }
 					newScreen = null;
 				}
 			}
@@ -147,10 +153,16 @@ namespace xServer.Core.Commands
 						Bitmap newScreen = client.Value.StreamCodec.DecodeData(ms);
 
 						client.Value.LastDesktop = newScreen;
-						client.Value.FrmRdp.Invoke((MethodInvoker) delegate
-						{
-							client.Value.FrmRdp.picDesktop.Image = (Bitmap) newScreen.Clone();
-						});
+
+                        try
+                        {
+                            client.Value.FrmRdp.Invoke((MethodInvoker)delegate
+                            {
+                                client.Value.FrmRdp.picDesktop.Image = (Bitmap)newScreen.Clone();
+                            });
+                        }
+                        catch
+                        { }
 
 						newScreen = null;
 					}


### PR DESCRIPTION
added try catch blocks due to server application crashing while closing
the remote desktop form.  If timed right, while closing the remote
desktop form, the command handler would be in the midst of accessing an
already disposed form causing server to hang.