### PR TITLE
Bugfix with Remote Desktop

### DIFF
--- a/Server/Core/Commands/CommandHandler.cs
+++ b/Server/Core/Commands/CommandHandler.cs
@@ -14,7 +14,6 @@ namespace xServer.Core.Commands
 	public static class CommandHandler
 	{
 		private const string DELIMITER = "$E$";
-		private static int lastQuality = -1;
 
 		public static void HandleInitialize(Client client, Initialize packet)
 		{
@@ -117,8 +116,8 @@ namespace xServer.Core.Commands
 			if (client.Value.LastDesktop == null)
 			{
 				client.Value.StreamCodec = new UnsafeStreamCodec();
-				if (lastQuality < 0)
-					lastQuality = packet.Quality;
+				if (client.Value.LastQuality < 0)
+                    client.Value.LastQuality = packet.Quality;
 
 				using (MemoryStream ms = new MemoryStream(packet.Image))
 				{
@@ -144,10 +143,10 @@ namespace xServer.Core.Commands
 				{
 					lock (client.Value.StreamCodec)
 					{
-						if (lastQuality != packet.Quality)
+                        if (client.Value.LastQuality != packet.Quality)
 						{
 							client.Value.StreamCodec = new UnsafeStreamCodec();
-							lastQuality = packet.Quality;
+                            client.Value.LastQuality = packet.Quality;
 						}
 
 						Bitmap newScreen = client.Value.StreamCodec.DecodeData(ms);

--- a/Server/Core/UserState.cs
+++ b/Server/Core/UserState.cs
@@ -27,6 +27,8 @@ namespace xServer.Core
         public bool LastDesktopSeen { get; set; }
         public bool LastDirectorySeen { get; set; }
 
+        public int LastQuality { get; set; }
+
         public Bitmap LastDesktop { get; set; }
 
         public UnsafeStreamCodec StreamCodec { get; set; }
@@ -36,6 +38,7 @@ namespace xServer.Core
             IsAuthenticated = false;
             LastDesktopSeen = true;
             LastDirectorySeen = true;
+            LastQuality = -1;
         }
 
         public void DisposeForms()


### PR DESCRIPTION
Moved static field to property so command handler gets the initial -1
check starting RDP.  The command handler is static so if a client disconnects the static field will have the data from the last quality used before disconnecting which caused server to hang using a different quality when starting the RDP