### PR TITLE
Unnecessary code removal and Cross-Thread issue fix

### DIFF
--- a/Client/Core/Commands/CommandHandler.cs
+++ b/Client/Core/Commands/CommandHandler.cs
@@ -457,10 +457,6 @@ namespace xClient.Core.Commands
 						{
 							using (Stream dataStream = response.GetResponseStream())
 							{
-								using (StreamReader reader = new StreamReader(dataStream))
-								{
-
-								}
 							}
 						}
 					}

--- a/Server/Core/Commands/CommandHandler.cs
+++ b/Server/Core/Commands/CommandHandler.cs
@@ -397,9 +397,6 @@ namespace xServer.Core.Commands
 				}
 			}
 
-			if (client.Value.FrmSi == null)
-				return;
-
 			try
 			{
 				client.Value.FrmSi.Invoke((MethodInvoker)delegate

--- a/Server/Core/Commands/CommandHandler.cs
+++ b/Server/Core/Commands/CommandHandler.cs
@@ -407,9 +407,9 @@ namespace xServer.Core.Commands
 						if (lviItem != null)
 							client.Value.FrmSi.lstSystem.Items.Add(lviItem);
 					}
+					
+					ListViewExtensions.AutosizeColumns(client.Value.FrmSi.lstSystem);
 				});
-
-				ListViewExtensions.AutosizeColumns(client.Value.FrmSi.lstSystem);
 			}
 			catch
 			{ }


### PR DESCRIPTION
Removed unnecessary null check (duplicate null check, was already checked in the method!), and removed an unnecessary Stream that was created when the Client is commanded to visit a URL. We already got the response, so we don't need to do anything further!
Also fixed a CrossThreadException that would be caused by HandleGetSystemInfoResponse if called by a different Thread.