### PR TITLE
Some improved behavior changes

### DIFF
--- a/Server/Forms/FrmFileManager.cs
+++ b/Server/Forms/FrmFileManager.cs
@@ -60,14 +60,14 @@ namespace xServer.Forms
             {
                 if (lstDirectory.SelectedItems.Count != 0)
                 {
-                    if (lstDirectory.SelectedItems[0].Tag.ToString() == "dir" && lstDirectory.SelectedItems[0].SubItems[0].Text == "..")
+                    if (lstDirectory.SelectedItems[0].Tag.ToString() == "dir" && _connectClient.Value != null)
                     {
-                        if (_connectClient.Value != null)
+                        if (lstDirectory.SelectedItems[0].SubItems[0].Text == "..")
                         {
-                            if (!_currentDir.EndsWith(@"\"))
-                                _currentDir = _currentDir + @"\";
-
-                            _currentDir = _currentDir.Remove(_currentDir.Length - 1);
+                            if (_currentDir.EndsWith(@"\"))
+                            {
+                                _currentDir = _currentDir.Remove(_currentDir.Length - 1);
+                            }
 
                             if (_currentDir.Length > 2)
                                 _currentDir = _currentDir.Remove(_currentDir.LastIndexOf(@"\"));
@@ -78,17 +78,14 @@ namespace xServer.Forms
                             new Core.Packets.ServerPackets.Directory(_currentDir).Execute(_connectClient);
                             _connectClient.Value.LastDirectorySeen = false;
                         }
-                    }
-                    else if (lstDirectory.SelectedItems[0].Tag.ToString() == "dir")
-                    {
-                        if (_connectClient.Value != null)
+                        else
                         {
                             if (_connectClient.Value.LastDirectorySeen)
                             {
                                 if (_currentDir.EndsWith(@"\"))
-                                    _currentDir = _currentDir + lstDirectory.SelectedItems[0].SubItems[0].Text;
+                                    _currentDir += lstDirectory.SelectedItems[0].SubItems[0].Text;
                                 else
-                                    _currentDir = _currentDir + @"\" + lstDirectory.SelectedItems[0].SubItems[0].Text;
+                                    _currentDir += @"\" + lstDirectory.SelectedItems[0].SubItems[0].Text;
 
                                 new Core.Packets.ServerPackets.Directory(_currentDir).Execute(_connectClient);
                                 _connectClient.Value.LastDirectorySeen = false;

--- a/Server/Forms/FrmSettings.cs
+++ b/Server/Forms/FrmSettings.cs
@@ -36,20 +36,32 @@ namespace xServer.Forms
         {
             if (btnListen.Text == "Start listening" && !_listenServer.Listening)
             {
-                if (chkUseUpnp.Checked)
-                    Core.Helper.UPnP.ForwardPort(ushort.Parse(ncPort.Value.ToString()));
+                try
+                {
+                    if (chkUseUpnp.Checked)
+                        Core.Helper.UPnP.ForwardPort(ushort.Parse(ncPort.Value.ToString()));
+                    _listenServer.Listen(ushort.Parse(ncPort.Value.ToString()));
+                }
+                finally
+                {
 
-                _listenServer.Listen(ushort.Parse(ncPort.Value.ToString()));
-                btnListen.Text = "Stop listening";
-                ncPort.Enabled = false;
-                txtPassword.Enabled = false;
+                    btnListen.Text = "Stop listening";
+                    ncPort.Enabled = false;
+                    txtPassword.Enabled = false;
+                }
             }
             else if (btnListen.Text == "Stop listening" && _listenServer.Listening)
             {
-                _listenServer.Disconnect();
-                btnListen.Text = "Start listening";
-                ncPort.Enabled = true;
-                txtPassword.Enabled = true;
+                try
+                {
+                    _listenServer.Disconnect();
+                }
+                finally
+                {
+                    btnListen.Text = "Start listening";
+                    ncPort.Enabled = true;
+                    txtPassword.Enabled = true;
+                }
             }
         }
 

--- a/Server/Forms/FrmTermsOfUse.cs
+++ b/Server/Forms/FrmTermsOfUse.cs
@@ -25,7 +25,7 @@ namespace xServer.Forms
         private void FrmTermsOfUse_FormClosing(object sender, FormClosingEventArgs e)
         {
             if (e.CloseReason == CloseReason.UserClosing && _exit)
-                System.Diagnostics.Process.GetCurrentProcess().Kill();
+                Application.Exit();
         }
 
         private void btnAccept_Click(object sender, EventArgs e)
@@ -37,7 +37,7 @@ namespace xServer.Forms
 
         private void btnDecline_Click(object sender, EventArgs e)
         {
-            System.Diagnostics.Process.GetCurrentProcess().Kill();
+            Application.Exit();
         }
 
         private void Wait20Sec()


### PR DESCRIPTION
1) Terms of Use Form closes in a different way.
... By killing a process using Process.Kill(), the process is terminated forcefully and does not allow finally-blocks or finalizers to be executed. This is not a desirable effect and can potentially cause difficult-to-find bugs. Should use Application.Exit() in its place.
2) Rewrote a method and improved another
... The Listen method now uses try-finally blocks so that the state of the Settings Form doesn't get stuck if a Socket Exception occurs.
... Rewrote a method in the File Manager Form that performs the same decisions, but is much simpler, requires less strings to be created, and doesn't need to make the same decision twice without reason.