### PR TITLE
Bugfix with Remote Desktop

### DIFF
--- a/Client/Core/Commands/CommandHandler.cs
+++ b/Client/Core/Commands/CommandHandler.cs
@@ -233,19 +233,19 @@ namespace xClient.Core.Commands
 
 			using (MemoryStream stream = new MemoryStream())
 			{
-                try
-                {
-                    StreamCodec.CodeImage(bmpdata.Scan0,
-                        new Rectangle(0, 0, LastDesktopScreenshot.Width, LastDesktopScreenshot.Height),
-                        new Size(LastDesktopScreenshot.Width, LastDesktopScreenshot.Height), LastDesktopScreenshot.PixelFormat,
-                        stream);
-                    new Packets.ClientPackets.DesktopResponse(stream.ToArray(), StreamCodec.ImageQuality, StreamCodec.Monitor).Execute(client);
-                }
-                catch
-                {
-                    new Packets.ClientPackets.DesktopResponse(null, StreamCodec.ImageQuality, StreamCodec.Monitor).Execute(client);
-                    StreamCodec = null;
-                }
+				try
+				{
+					StreamCodec.CodeImage(bmpdata.Scan0,
+						new Rectangle(0, 0, LastDesktopScreenshot.Width, LastDesktopScreenshot.Height),
+						new Size(LastDesktopScreenshot.Width, LastDesktopScreenshot.Height), LastDesktopScreenshot.PixelFormat,
+						stream);
+					new Packets.ClientPackets.DesktopResponse(stream.ToArray(), StreamCodec.ImageQuality, StreamCodec.Monitor).Execute(client);
+				}
+				catch
+				{
+					new Packets.ClientPackets.DesktopResponse(null, StreamCodec.ImageQuality, StreamCodec.Monitor).Execute(client);
+					StreamCodec = null;
+				}
 			}
 
 			LastDesktopScreenshot.UnlockBits(bmpdata);

--- a/Client/Core/Commands/CommandHandler.cs
+++ b/Client/Core/Commands/CommandHandler.cs
@@ -233,11 +233,19 @@ namespace xClient.Core.Commands
 
 			using (MemoryStream stream = new MemoryStream())
 			{
-				StreamCodec.CodeImage(bmpdata.Scan0,
-					new Rectangle(0, 0, LastDesktopScreenshot.Width, LastDesktopScreenshot.Height),
-					new Size(LastDesktopScreenshot.Width, LastDesktopScreenshot.Height), LastDesktopScreenshot.PixelFormat,
-					stream);
-				new Packets.ClientPackets.DesktopResponse(stream.ToArray(), StreamCodec.ImageQuality, StreamCodec.Monitor).Execute(client);
+                try
+                {
+                    StreamCodec.CodeImage(bmpdata.Scan0,
+                        new Rectangle(0, 0, LastDesktopScreenshot.Width, LastDesktopScreenshot.Height),
+                        new Size(LastDesktopScreenshot.Width, LastDesktopScreenshot.Height), LastDesktopScreenshot.PixelFormat,
+                        stream);
+                    new Packets.ClientPackets.DesktopResponse(stream.ToArray(), StreamCodec.ImageQuality, StreamCodec.Monitor).Execute(client);
+                }
+                catch
+                {
+                    new Packets.ClientPackets.DesktopResponse(null, StreamCodec.ImageQuality, StreamCodec.Monitor).Execute(client);
+                    StreamCodec = null;
+                }
 			}
 
 			LastDesktopScreenshot.UnlockBits(bmpdata);

--- a/Server/Core/Commands/CommandHandler.cs
+++ b/Server/Core/Commands/CommandHandler.cs
@@ -111,6 +111,24 @@ namespace xServer.Core.Commands
 			if (client.Value.FrmRdp == null)
 				return;
 
+			if (packet.Image == null)
+			{
+				try
+				{
+					client.Value.FrmRdp.Invoke((MethodInvoker)delegate
+					{
+						client.Value.FrmRdp.picDesktop.Image = (Bitmap)client.Value.LastDesktop;
+					});
+				}
+				catch
+				{ }
+
+				client.Value.LastDesktop = null;
+				client.Value.LastDesktopSeen = true;
+
+				return;
+			}
+
 			// we can not dispose all bitmaps here, cause they are later used again in `client.Value.LastDesktop`
 			if (client.Value.LastDesktop == null)
 			{


### PR DESCRIPTION
Fixed a bug where changing resolutions while Remote Desktop is running
would crash both the client + server.  This fix ensures that the Remote
Desktop features continues to run accurately after changing resolutions
on the client.