### PR TITLE
Fixed null reference crash

### DIFF
--- a/Server/Forms/FrmReverseProxy.cs
+++ b/Server/Forms/FrmReverseProxy.cs
@@ -103,7 +103,8 @@ namespace xServer.Forms
 
         private void btnStop_Click(object sender, EventArgs e)
         {
-            RefreshTimer.Stop();
+            if (RefreshTimer != null)
+                RefreshTimer.Stop();
             btnStart.Enabled = true;
             btnStop.Enabled = false;
             if (SocksServer != null)


### PR DESCRIPTION
Closing this form without doing anything causes a crash because RefreshTimer hasn't been initialized yet