### PR TITLE
Changed the send method's parameter type for client/server

### DIFF
--- a/Client/Core/Client.cs
+++ b/Client/Core/Client.cs
@@ -255,7 +255,7 @@ namespace xClient.Core
             }
         }
 
-        public void Send<T>(IPacket packet) where T : IPacket
+        public void Send<T>(T packet) where T : IPacket
         {
             lock (_handle)
             {
@@ -266,7 +266,7 @@ namespace xClient.Core
                 {
                     using (MemoryStream ms = new MemoryStream())
                     {
-                        Serializer.SerializeWithLengthPrefix<T>(ms, (T) packet, PrefixStyle.Fixed32);
+                        Serializer.SerializeWithLengthPrefix<T>(ms, packet, PrefixStyle.Fixed32);
 
                         byte[] data = ms.ToArray();
 

--- a/Client/Core/Packets/ClientPackets/DesktopResponse.cs
+++ b/Client/Core/Packets/ClientPackets/DesktopResponse.cs
@@ -27,7 +27,7 @@ namespace xClient.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<DesktopResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ClientPackets/DirectoryResponse.cs
+++ b/Client/Core/Packets/ClientPackets/DirectoryResponse.cs
@@ -27,7 +27,7 @@ namespace xClient.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<DirectoryResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ClientPackets/DownloadFileResponse.cs
+++ b/Client/Core/Packets/ClientPackets/DownloadFileResponse.cs
@@ -40,7 +40,7 @@ namespace xClient.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<DownloadFileResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ClientPackets/DrivesResponse.cs
+++ b/Client/Core/Packets/ClientPackets/DrivesResponse.cs
@@ -19,7 +19,7 @@ namespace xClient.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<DrivesResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ClientPackets/GetLogsResponse.cs
+++ b/Client/Core/Packets/ClientPackets/GetLogsResponse.cs
@@ -40,7 +40,7 @@ namespace xClient.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<GetLogsResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ClientPackets/GetProcessesResponse.cs
+++ b/Client/Core/Packets/ClientPackets/GetProcessesResponse.cs
@@ -27,7 +27,7 @@ namespace xClient.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<GetProcessesResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ClientPackets/GetStartupItemsResponse.cs
+++ b/Client/Core/Packets/ClientPackets/GetStartupItemsResponse.cs
@@ -20,7 +20,7 @@ namespace xClient.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<GetStartupItemsResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ClientPackets/GetSystemInfoResponse.cs
+++ b/Client/Core/Packets/ClientPackets/GetSystemInfoResponse.cs
@@ -19,7 +19,7 @@ namespace xClient.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<GetSystemInfoResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ClientPackets/Initialize.cs
+++ b/Client/Core/Packets/ClientPackets/Initialize.cs
@@ -52,7 +52,7 @@ namespace xClient.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<Initialize>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ClientPackets/MonitorsResponse.cs
+++ b/Client/Core/Packets/ClientPackets/MonitorsResponse.cs
@@ -19,7 +19,7 @@ namespace xClient.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<MonitorsResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ClientPackets/ShellCommandResponse.cs
+++ b/Client/Core/Packets/ClientPackets/ShellCommandResponse.cs
@@ -19,7 +19,7 @@ namespace xClient.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<ShellCommandResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ClientPackets/Status.cs
+++ b/Client/Core/Packets/ClientPackets/Status.cs
@@ -19,7 +19,7 @@ namespace xClient.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<Status>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ClientPackets/UserStatus.cs
+++ b/Client/Core/Packets/ClientPackets/UserStatus.cs
@@ -19,7 +19,7 @@ namespace xClient.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<UserStatus>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/Action.cs
+++ b/Client/Core/Packets/ServerPackets/Action.cs
@@ -19,7 +19,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Action>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/AddStartupItem.cs
+++ b/Client/Core/Packets/ServerPackets/AddStartupItem.cs
@@ -27,7 +27,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<AddStartupItem>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/Delete.cs
+++ b/Client/Core/Packets/ServerPackets/Delete.cs
@@ -23,7 +23,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Delete>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/Desktop.cs
+++ b/Client/Core/Packets/ServerPackets/Desktop.cs
@@ -23,7 +23,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Desktop>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/Directory.cs
+++ b/Client/Core/Packets/ServerPackets/Directory.cs
@@ -19,7 +19,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Directory>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/Disconnect.cs
+++ b/Client/Core/Packets/ServerPackets/Disconnect.cs
@@ -11,7 +11,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Disconnect>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/DownloadAndExecute.cs
+++ b/Client/Core/Packets/ServerPackets/DownloadAndExecute.cs
@@ -23,7 +23,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<DownloadAndExecute>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/DownloadFile.cs
+++ b/Client/Core/Packets/ServerPackets/DownloadFile.cs
@@ -23,7 +23,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<DownloadFile>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/DownloadFileCanceled.cs
+++ b/Client/Core/Packets/ServerPackets/DownloadFileCanceled.cs
@@ -19,7 +19,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<DownloadFileCanceled>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/Drives.cs
+++ b/Client/Core/Packets/ServerPackets/Drives.cs
@@ -11,7 +11,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Drives>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/GetLogs.cs
+++ b/Client/Core/Packets/ServerPackets/GetLogs.cs
@@ -9,7 +9,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<GetLogs>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/GetProcesses.cs
+++ b/Client/Core/Packets/ServerPackets/GetProcesses.cs
@@ -11,7 +11,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<GetProcesses>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/GetStartupItems.cs
+++ b/Client/Core/Packets/ServerPackets/GetStartupItems.cs
@@ -11,7 +11,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<GetStartupItems>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/GetSystemInfo.cs
+++ b/Client/Core/Packets/ServerPackets/GetSystemInfo.cs
@@ -11,7 +11,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<GetSystemInfo>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/InitializeCommand.cs
+++ b/Client/Core/Packets/ServerPackets/InitializeCommand.cs
@@ -11,7 +11,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<InitializeCommand>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/KillProcess.cs
+++ b/Client/Core/Packets/ServerPackets/KillProcess.cs
@@ -19,7 +19,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<KillProcess>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/Monitors.cs
+++ b/Client/Core/Packets/ServerPackets/Monitors.cs
@@ -11,7 +11,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Monitors>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/MouseClick.cs
+++ b/Client/Core/Packets/ServerPackets/MouseClick.cs
@@ -31,7 +31,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<MouseClick>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/Reconnect.cs
+++ b/Client/Core/Packets/ServerPackets/Reconnect.cs
@@ -11,7 +11,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Reconnect>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/Rename.cs
+++ b/Client/Core/Packets/ServerPackets/Rename.cs
@@ -27,7 +27,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Rename>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/ShellCommand.cs
+++ b/Client/Core/Packets/ServerPackets/ShellCommand.cs
@@ -19,7 +19,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<ShellCommand>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/ShowMessageBox.cs
+++ b/Client/Core/Packets/ServerPackets/ShowMessageBox.cs
@@ -31,7 +31,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<ShowMessageBox>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/StartProcess.cs
+++ b/Client/Core/Packets/ServerPackets/StartProcess.cs
@@ -19,7 +19,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<StartProcess>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/Uninstall.cs
+++ b/Client/Core/Packets/ServerPackets/Uninstall.cs
@@ -11,7 +11,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Uninstall>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/Update.cs
+++ b/Client/Core/Packets/ServerPackets/Update.cs
@@ -19,7 +19,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Update>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/UploadAndExecute.cs
+++ b/Client/Core/Packets/ServerPackets/UploadAndExecute.cs
@@ -39,7 +39,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<UploadAndExecute>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/ServerPackets/VisitWebsite.cs
+++ b/Client/Core/Packets/ServerPackets/VisitWebsite.cs
@@ -23,7 +23,7 @@ namespace xClient.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<VisitWebsite>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/Packets/UnknownPacket.cs
+++ b/Client/Core/Packets/UnknownPacket.cs
@@ -19,7 +19,7 @@ namespace xClient.Core.Packets
 
         public void Execute(Client client)
         {
-            client.Send<UnknownPacket>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/ReverseProxy/Packets/ReverseProxyConnect.cs
+++ b/Client/Core/ReverseProxy/Packets/ReverseProxyConnect.cs
@@ -28,7 +28,7 @@ namespace xClient.Core.ReverseProxy.Packets
 
         public void Execute(Client client)
         {
-            client.Send<ReverseProxyConnect>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/ReverseProxy/Packets/ReverseProxyConnectResponse.cs
+++ b/Client/Core/ReverseProxy/Packets/ReverseProxyConnectResponse.cs
@@ -51,7 +51,7 @@ namespace xClient.Core.ReverseProxy.Packets
 
         public void Execute(Client client)
         {
-            client.Send<ReverseProxyConnectResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/ReverseProxy/Packets/ReverseProxyData.cs
+++ b/Client/Core/ReverseProxy/Packets/ReverseProxyData.cs
@@ -24,7 +24,7 @@ namespace xClient.Core.ReverseProxy.Packets
 
         public void Execute(Client client)
         {
-            client.Send<ReverseProxyData>(this);
+            client.Send(this);
         }
     }
 }

--- a/Client/Core/ReverseProxy/Packets/ReverseProxyDisconnect.cs
+++ b/Client/Core/ReverseProxy/Packets/ReverseProxyDisconnect.cs
@@ -20,7 +20,7 @@ namespace xClient.Core.ReverseProxy.Packets
 
         public void Execute(Client client)
         {
-            client.Send<ReverseProxyDisconnect>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Client.cs
+++ b/Server/Core/Client.cs
@@ -237,7 +237,7 @@ namespace xServer.Core
             }
         }
 
-        public void Send<T>(IPacket packet) where T : IPacket
+        public void Send<T>(T packet) where T : IPacket
         {
             lock (_handle)
             {
@@ -248,7 +248,7 @@ namespace xServer.Core
                 {
                     using (MemoryStream ms = new MemoryStream())
                     {
-                        Serializer.SerializeWithLengthPrefix<T>(ms, (T) packet, PrefixStyle.Fixed32);
+                        Serializer.SerializeWithLengthPrefix<T>(ms, packet, PrefixStyle.Fixed32);
 
                         byte[] data = ms.ToArray();
 

--- a/Server/Core/Packets/ClientPackets/DesktopResponse.cs
+++ b/Server/Core/Packets/ClientPackets/DesktopResponse.cs
@@ -27,7 +27,7 @@ namespace xServer.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<DesktopResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ClientPackets/DirectoryResponse.cs
+++ b/Server/Core/Packets/ClientPackets/DirectoryResponse.cs
@@ -27,7 +27,7 @@ namespace xServer.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<DirectoryResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ClientPackets/DownloadFileResponse.cs
+++ b/Server/Core/Packets/ClientPackets/DownloadFileResponse.cs
@@ -40,7 +40,7 @@ namespace xServer.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<DownloadFileResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ClientPackets/DrivesResponse.cs
+++ b/Server/Core/Packets/ClientPackets/DrivesResponse.cs
@@ -19,7 +19,7 @@ namespace xServer.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<DrivesResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ClientPackets/GetLogsResponse.cs
+++ b/Server/Core/Packets/ClientPackets/GetLogsResponse.cs
@@ -40,7 +40,7 @@ namespace xServer.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<GetLogsResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ClientPackets/GetProcessesResponse.cs
+++ b/Server/Core/Packets/ClientPackets/GetProcessesResponse.cs
@@ -27,7 +27,7 @@ namespace xServer.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<GetProcessesResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ClientPackets/GetStartupItemsResponse.cs
+++ b/Server/Core/Packets/ClientPackets/GetStartupItemsResponse.cs
@@ -20,7 +20,7 @@ namespace xServer.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<GetStartupItemsResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ClientPackets/GetSystemInfoResponse.cs
+++ b/Server/Core/Packets/ClientPackets/GetSystemInfoResponse.cs
@@ -19,7 +19,7 @@ namespace xServer.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<GetSystemInfoResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ClientPackets/Initialize.cs
+++ b/Server/Core/Packets/ClientPackets/Initialize.cs
@@ -52,7 +52,7 @@ namespace xServer.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<Initialize>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ClientPackets/MonitorsResponse.cs
+++ b/Server/Core/Packets/ClientPackets/MonitorsResponse.cs
@@ -19,7 +19,7 @@ namespace xServer.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<MonitorsResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ClientPackets/ShellCommandResponse.cs
+++ b/Server/Core/Packets/ClientPackets/ShellCommandResponse.cs
@@ -19,7 +19,7 @@ namespace xServer.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<ShellCommandResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ClientPackets/Status.cs
+++ b/Server/Core/Packets/ClientPackets/Status.cs
@@ -19,7 +19,7 @@ namespace xServer.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<Status>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ClientPackets/UserStatus.cs
+++ b/Server/Core/Packets/ClientPackets/UserStatus.cs
@@ -19,7 +19,7 @@ namespace xServer.Core.Packets.ClientPackets
 
         public void Execute(Client client)
         {
-            client.Send<UserStatus>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/Action.cs
+++ b/Server/Core/Packets/ServerPackets/Action.cs
@@ -19,7 +19,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Action>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/AddStartupItem.cs
+++ b/Server/Core/Packets/ServerPackets/AddStartupItem.cs
@@ -27,7 +27,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<AddStartupItem>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/Delete.cs
+++ b/Server/Core/Packets/ServerPackets/Delete.cs
@@ -23,7 +23,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Delete>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/Desktop.cs
+++ b/Server/Core/Packets/ServerPackets/Desktop.cs
@@ -23,7 +23,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Desktop>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/Directory.cs
+++ b/Server/Core/Packets/ServerPackets/Directory.cs
@@ -19,7 +19,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Directory>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/Disconnect.cs
+++ b/Server/Core/Packets/ServerPackets/Disconnect.cs
@@ -11,7 +11,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Disconnect>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/DownloadAndExecute.cs
+++ b/Server/Core/Packets/ServerPackets/DownloadAndExecute.cs
@@ -23,7 +23,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<DownloadAndExecute>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/DownloadFile.cs
+++ b/Server/Core/Packets/ServerPackets/DownloadFile.cs
@@ -23,7 +23,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<DownloadFile>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/DownloadFileCanceled.cs
+++ b/Server/Core/Packets/ServerPackets/DownloadFileCanceled.cs
@@ -19,7 +19,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<DownloadFileCanceled>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/Drives.cs
+++ b/Server/Core/Packets/ServerPackets/Drives.cs
@@ -11,7 +11,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Drives>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/GetLogs.cs
+++ b/Server/Core/Packets/ServerPackets/GetLogs.cs
@@ -9,7 +9,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<GetLogs>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/GetProcesses.cs
+++ b/Server/Core/Packets/ServerPackets/GetProcesses.cs
@@ -11,7 +11,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<GetProcesses>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/GetStartupItems.cs
+++ b/Server/Core/Packets/ServerPackets/GetStartupItems.cs
@@ -11,7 +11,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<GetStartupItems>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/GetSystemInfo.cs
+++ b/Server/Core/Packets/ServerPackets/GetSystemInfo.cs
@@ -11,7 +11,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<GetSystemInfo>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/InitializeCommand.cs
+++ b/Server/Core/Packets/ServerPackets/InitializeCommand.cs
@@ -11,7 +11,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<InitializeCommand>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/KillProcess.cs
+++ b/Server/Core/Packets/ServerPackets/KillProcess.cs
@@ -19,7 +19,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<KillProcess>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/Monitors.cs
+++ b/Server/Core/Packets/ServerPackets/Monitors.cs
@@ -11,7 +11,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Monitors>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/MouseClick.cs
+++ b/Server/Core/Packets/ServerPackets/MouseClick.cs
@@ -31,7 +31,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<MouseClick>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/Reconnect.cs
+++ b/Server/Core/Packets/ServerPackets/Reconnect.cs
@@ -11,7 +11,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Reconnect>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/Rename.cs
+++ b/Server/Core/Packets/ServerPackets/Rename.cs
@@ -27,7 +27,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Rename>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/ShellCommand.cs
+++ b/Server/Core/Packets/ServerPackets/ShellCommand.cs
@@ -19,7 +19,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<ShellCommand>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/ShowMessageBox.cs
+++ b/Server/Core/Packets/ServerPackets/ShowMessageBox.cs
@@ -31,7 +31,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<ShowMessageBox>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/StartProcess.cs
+++ b/Server/Core/Packets/ServerPackets/StartProcess.cs
@@ -19,7 +19,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<StartProcess>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/Uninstall.cs
+++ b/Server/Core/Packets/ServerPackets/Uninstall.cs
@@ -11,7 +11,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Uninstall>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/Update.cs
+++ b/Server/Core/Packets/ServerPackets/Update.cs
@@ -19,7 +19,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<Update>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/UploadAndExecute.cs
+++ b/Server/Core/Packets/ServerPackets/UploadAndExecute.cs
@@ -39,7 +39,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<UploadAndExecute>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/ServerPackets/VisitWebsite.cs
+++ b/Server/Core/Packets/ServerPackets/VisitWebsite.cs
@@ -23,7 +23,7 @@ namespace xServer.Core.Packets.ServerPackets
 
         public void Execute(Client client)
         {
-            client.Send<VisitWebsite>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/Packets/UnknownPacket.cs
+++ b/Server/Core/Packets/UnknownPacket.cs
@@ -19,7 +19,7 @@ namespace xServer.Core.Packets
 
         public void Execute(Client client)
         {
-            client.Send<UnknownPacket>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/ReverseProxy/Packets/ReverseProxyConnect.cs
+++ b/Server/Core/ReverseProxy/Packets/ReverseProxyConnect.cs
@@ -28,7 +28,7 @@ namespace xServer.Core.ReverseProxy.Packets
 
         public void Execute(Client client)
         {
-            client.Send<ReverseProxyConnect>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/ReverseProxy/Packets/ReverseProxyConnectResponse.cs
+++ b/Server/Core/ReverseProxy/Packets/ReverseProxyConnectResponse.cs
@@ -35,7 +35,7 @@ namespace xServer.Core.ReverseProxy.Packets
 
         public void Execute(Client client)
         {
-            client.Send<ReverseProxyConnectResponse>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/ReverseProxy/Packets/ReverseProxyData.cs
+++ b/Server/Core/ReverseProxy/Packets/ReverseProxyData.cs
@@ -24,7 +24,7 @@ namespace xServer.Core.ReverseProxy.Packets
 
         public void Execute(Client client)
         {
-            client.Send<ReverseProxyData>(this);
+            client.Send(this);
         }
     }
 }

--- a/Server/Core/ReverseProxy/Packets/ReverseProxyDisconnect.cs
+++ b/Server/Core/ReverseProxy/Packets/ReverseProxyDisconnect.cs
@@ -20,7 +20,7 @@ namespace xServer.Core.ReverseProxy.Packets
 
         public void Execute(Client client)
         {
-            client.Send<ReverseProxyDisconnect>(this);
+            client.Send(this);
         }
     }
 }


### PR DESCRIPTION
<h1>Why?</h1>
The generic type (restricted to those inheriting IPacket) is accepted by the Send method for the client and the server. I knew that this functionality is used to restrict the type of the packet, and the generic type is used to specify exactly what the type was. However, because the parameter was of the type IPacket in this case (not necessarily defined in type, rather than being required to inherit IPacket of course), the send method would end up boxing the parameter (packet), then would later unbox it with the type T given to the Send method. Doing this eliminates the need to box/unbox the packet.
Also, type T would be required to be of the type assigned to the parameter (packet), ensuring safety of the types being used.
<br />
<h1>Safety</h1>
Imagine we call <code>Send(bracket)GetProcesses(end_bracket)(this)</code> where "this" is a reference to a type of packet that cannot cast in a manner that allows serialization of the packet. It would obviously fail, and would result in (likely) unexpected and hard to find behavior. There is no need in our case to specify the specific type of the parameter because the generic type (as defined by the parameter) will be determined for us.
<br />
<h1>Is this concept against the implementation of ProtoBuf?</h1>
Nope. ProtoBuf actually follows this design already:
<code>
public static void SerializeWithLengthPrefix(bracket)T(end_bracket)(Stream destination, T instance, PrefixStyle style)
        {
            SerializeWithLengthPrefix(bracket)T(end_bracket)(destination, instance, style, 0);
        }
</code>
<br />
<h1>Additional Notes</h1>
- If necessary, one can still achieve the desired behavior of specifying a more-specific base type (T), if and only if type (T) specified can inherit both "IPacket" and the type of the parameter specified.
- The List type also uses this design. This is why (when you provide the object when constructing a List) you do not also have to specify the type again. This feature means that providing an object to the object receiving the generic type naturally ensures type safety at compile-time.