### PR TITLE
IDisposable TypeloadException fix

### DIFF
--- a/Server/Core/Build/Renamer.cs
+++ b/Server/Core/Build/Renamer.cs
@@ -61,7 +61,7 @@ namespace xServer.Core.Build
             if (typeDef.Namespace.StartsWith("My") || typeDef.Namespace.StartsWith("xClient.Core.Packets") ||
                 typeDef.Namespace == "xClient.Core" || typeDef.Namespace == "xClient.Core.Elevation" ||
                 typeDef.Namespace == "xClient.Core.Compression" || typeDef.Namespace.StartsWith("ProtoBuf") ||
-                typeDef.Namespace.Contains("xClient.Core.ReverseProxy"))
+                typeDef.Namespace.Contains("xClient.Core.ReverseProxy") || typeDef.HasInterfaces)
                 return;
 
             TypeOverloader.GiveName(typeDef);


### PR DESCRIPTION
Ignore renaming types that implement interfaces.

I hope this is the correct way to do this, I couldn't find a way to find
a specific interface to exclude from obfuscation