### PR TITLE
Fixed server crash on FrmKeylogger

### DIFF
--- a/Server/Forms/FrmKeylogger.cs
+++ b/Server/Forms/FrmKeylogger.cs
@@ -55,7 +55,10 @@ namespace xServer.Forms
 
         private void lstLogs_ItemActivate(object sender, EventArgs e)
         {
-            wLogViewer.Navigate(Path.Combine(_path, lstLogs.SelectedItems[0].Text));
+            if (lstLogs.SelectedItems != null && lstLogs.SelectedItems.Count > 0)
+            {
+                wLogViewer.Navigate(Path.Combine(_path, lstLogs.SelectedItems[0].Text));
+            }
         }
 
         private void FrmKeylogger_FormClosing(object sender, FormClosingEventArgs e)


### PR DESCRIPTION
<h1>Reproduction of the issue</h1>
- Open up a keylogger form and make sure no entries are selected.
- Invoke the <b><a href="https://github.com/MaxXor/xRAT/blob/master/Server/Forms/FrmKeylogger.cs#L56">lstLogs_ItemActivate</a></b> method by pressing enter.
- Since no items are selected, it cannot index the 0th item of lstLogs' SelectedItems, causing an exception that is uncaught and crashes the server.