### PR TITLE
small behavior fix

### DIFF
--- a/Server/Forms/FrmMain.cs
+++ b/Server/Forms/FrmMain.cs
@@ -179,7 +179,7 @@ namespace xServer.Forms
             if (ListenServer.Listening)
                 ListenServer.Disconnect();
 
-            if (XMLSettings.UseUPnP)
+            if (XMLSettings.UseUPnP && ListenServer.Listening)
                 UPnP.RemovePort(ushort.Parse(XMLSettings.ListenPort.ToString()));
 
             nIcon.Visible = false;


### PR DESCRIPTION
only try to remove upnp settings if the server is listening, if you have this checked, closing the form will stall for a second or two even if the server is not listening.  It stalls for a second or two because we are  forwarding the port when we start the server, not when we open the form, so if i start the server form without starting the listen server and I have UPnP enabled, it will try to remove a port that hasn't been forwarded and it takes a while for the UPnP class to process this causing the form to hang