### PR TITLE
changed reconnect from milliseconds to seconds, improved reconnect attempt

### DIFF
--- a/Client/Config/Settings.cs
+++ b/Client/Config/Settings.cs
@@ -12,7 +12,7 @@ namespace xClient.Config
         public static string VERSION = "1.0.0.0d";
         public static string HOST = "localhost";
         public static ushort PORT = 4782;
-        public static int RECONNECTDELAY = 5000;
+        public static int RECONNECTDELAY = 1;
         public static string PASSWORD = "1234";
         public static string DIR = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
         public static string SUBFOLDER = "Test";
@@ -32,7 +32,7 @@ namespace xClient.Config
         public static string VERSION = "1.0.0.0r";
         public static string HOST = "localhost";
         public static ushort PORT = 4782;
-        public static int RECONNECTDELAY = 5000;
+        public static int RECONNECTDELAY = 300;
         public static string PASSWORD = "1234";
         public static string DIR = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
         public static string SUBFOLDER = "SUB";

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -167,7 +167,10 @@ namespace xClient
         private static void Connect()
         {
             TryAgain:
-            Thread.Sleep(250 + new Random().Next(0, 250));
+
+            //random sleep between 50% and 150% of the configured delay
+            int delayInMs = Settings.RECONNECTDELAY * 1000;
+            Thread.Sleep(new Random().Next(delayInMs) + delayInMs / 2);
 
             if (!_connected)
                 ConnectClient.Connect(Settings.HOST, Settings.PORT);

--- a/Server/Forms/FrmBuilder.Designer.cs
+++ b/Server/Forms/FrmBuilder.Designer.cs
@@ -31,7 +31,7 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmBuilder));
             this.groupConnection = new System.Windows.Forms.GroupBox();
-            this.lblMS = new System.Windows.Forms.Label();
+            this.lblSeconds = new System.Windows.Forms.Label();
             this.txtDelay = new System.Windows.Forms.TextBox();
             this.lblDelay = new System.Windows.Forms.Label();
             this.chkShowPass = new System.Windows.Forms.CheckBox();
@@ -97,7 +97,7 @@
             // 
             // groupConnection
             // 
-            this.groupConnection.Controls.Add(this.lblMS);
+            this.groupConnection.Controls.Add(this.lblSeconds);
             this.groupConnection.Controls.Add(this.txtDelay);
             this.groupConnection.Controls.Add(this.lblDelay);
             this.groupConnection.Controls.Add(this.chkShowPass);
@@ -114,14 +114,14 @@
             this.groupConnection.TabStop = false;
             this.groupConnection.Text = "Connection";
             // 
-            // lblMS
+            // lblSeconds
             // 
-            this.lblMS.AutoSize = true;
-            this.lblMS.Location = new System.Drawing.Point(186, 126);
-            this.lblMS.Name = "lblMS";
-            this.lblMS.Size = new System.Drawing.Size(21, 13);
-            this.lblMS.TabIndex = 9;
-            this.lblMS.Text = "ms";
+            this.lblSeconds.AutoSize = true;
+            this.lblSeconds.Location = new System.Drawing.Point(186, 126);
+            this.lblSeconds.Name = "lblSeconds";
+            this.lblSeconds.Size = new System.Drawing.Size(49, 13);
+            this.lblSeconds.TabIndex = 9;
+            this.lblSeconds.Text = "seconds";
             // 
             // txtDelay
             // 
@@ -130,7 +130,7 @@
             this.txtDelay.Name = "txtDelay";
             this.txtDelay.Size = new System.Drawing.Size(66, 22);
             this.txtDelay.TabIndex = 8;
-            this.txtDelay.Text = "5000";
+            this.txtDelay.Text = "300";
             this.txtDelay.TextChanged += new System.EventHandler(this.txtDelay_TextChanged);
             this.txtDelay.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.txtDelay_KeyPress);
             // 
@@ -745,7 +745,7 @@
         private System.Windows.Forms.Label lblRegistryKeyName;
         private System.Windows.Forms.CheckBox chkStartup;
         private System.Windows.Forms.Button btnBuild;
-        private System.Windows.Forms.Label lblMS;
+        private System.Windows.Forms.Label lblSeconds;
         private System.Windows.Forms.RadioButton rbSystem;
         private System.Windows.Forms.RadioButton rbProgramFiles;
         private System.Windows.Forms.PictureBox picUAC1;


### PR DESCRIPTION
I changed the reconnect delay from milliseconds to seconds. The builder form label changed to "seconds" and the client now multiplies the reconnect delay by 1000 to convert it to milliseconds. I modified the defaults for debug to be 1 second and for production to be 300 seconds, or 5 minutes. The previous value of 5 seconds created a much too obvious rapidly polling outgoing connection.

Additionally I modified the randomness in the reconnect timeout to always be between 50% and 150% of the configured value, allowing for a better randomly staggered reconnect time that is less likely to show up as a simple recurring pattern. If you use the 5 minute default that I set then the retry time will be between 2.5 minutes and 7.5 minutes.
