### PR TITLE
Better server validation

### DIFF
--- a/Server/Core/Commands/MiscHandler.cs
+++ b/Server/Core/Commands/MiscHandler.cs
@@ -11,7 +11,7 @@ namespace xServer.Core.Commands
     {
         public static void HandleShellCommandResponse(Client client, ShellCommandResponse packet)
         {
-            if (client.Value.FrmRs == null)
+            if (client.Value.FrmRs == null || string.IsNullOrEmpty(packet.Output))
                 return;
 
             if (packet.IsError)
@@ -22,6 +22,9 @@ namespace xServer.Core.Commands
 
         public static void HandleDownloadFileResponse(Client client, DownloadFileResponse packet)
         {
+            if (string.IsNullOrEmpty(packet.Filename))
+                return;
+
             if (!Directory.Exists(client.Value.DownloadDirectory))
                 Directory.CreateDirectory(client.Value.DownloadDirectory);
 

--- a/Server/Core/Commands/SurveillanceHandler.cs
+++ b/Server/Core/Commands/SurveillanceHandler.cs
@@ -94,6 +94,13 @@ namespace xServer.Core.Commands
 
             client.Value.FrmTm.ClearListview();
 
+            // None of the arrays containing the process' information can be null.
+            // The must also be the exact same length because each entry in the three
+            // different arrays represents one process.
+            if (packet.Processes == null || packet.IDs == null || packet.Titles == null ||
+                packet.Processes.Length != packet.IDs.Length || packet.Processes.Length != packet.Titles.Length)
+                return;
+
             new Thread(() =>
             {
                 for (int i = 0; i < packet.Processes.Length; i++)
@@ -125,6 +132,9 @@ namespace xServer.Core.Commands
             }
 
             string downloadPath = Path.Combine(client.Value.DownloadDirectory, "Logs\\");
+
+            if (string.IsNullOrEmpty(packet.Filename))
+                return;
 
             if (!Directory.Exists(downloadPath))
                 Directory.CreateDirectory(downloadPath);

--- a/Server/Core/Commands/SurveillanceHandler.cs
+++ b/Server/Core/Commands/SurveillanceHandler.cs
@@ -131,10 +131,10 @@ namespace xServer.Core.Commands
                 return;
             }
 
-            string downloadPath = Path.Combine(client.Value.DownloadDirectory, "Logs\\");
-
             if (string.IsNullOrEmpty(packet.Filename))
                 return;
+
+            string downloadPath = Path.Combine(client.Value.DownloadDirectory, "Logs\\");
 
             if (!Directory.Exists(downloadPath))
                 Directory.CreateDirectory(downloadPath);

--- a/Server/Core/Commands/SystemHandler.cs
+++ b/Server/Core/Commands/SystemHandler.cs
@@ -14,7 +14,7 @@ namespace xServer.Core.Commands
     {
         public static void HandleDrivesResponse(Client client, DrivesResponse packet)
         {
-            if (client.Value.FrmFm == null)
+            if (client.Value.FrmFm == null || packet.Drives == null)
                 return;
 
             client.Value.FrmFm.AddDrives(packet.Drives);
@@ -37,7 +37,7 @@ namespace xServer.Core.Commands
 
                 client.Value.FrmFm.AddItemToFileBrowser(lviBack);
 
-                if (packet.Folders.Length != 0)
+                if (packet.Folders != null && packet.Folders.Length != 0)
                 {
                     for (int i = 0; i < packet.Folders.Length; i++)
                     {
@@ -57,7 +57,7 @@ namespace xServer.Core.Commands
                     }
                 }
 
-                if (packet.Files.Length != 0)
+                if (packet.Files != null && packet.Files.Length != 0)
                 {
                     for (int i = 0; i < packet.Files.Length; i++)
                     {
@@ -84,6 +84,9 @@ namespace xServer.Core.Commands
 
         public static void HandleGetSystemInfoResponse(Client client, GetSystemInfoResponse packet)
         {
+            if (packet.SystemInfos == null)
+                return;
+
             if (XMLSettings.ShowToolTip)
             {
                 var builder = new StringBuilder();


### PR DESCRIPTION
<h1>Reason</h1>
A client should <b>never</b> have the ability to break the server (cause an uncaught exception) by sending packets with invalid or otherwise unusable data.

<h1>Changes</h1>
- Added more restrictive validation to ensure usable information by the received packets on the handlers before use. This makes sure that a client that may make a strange request with bad data without causing a server crash.