### PR TITLE
PacketHandler fix

### DIFF
--- a/Server/Core/Packets/PacketHandler.cs
+++ b/Server/Core/Packets/PacketHandler.cs
@@ -10,6 +10,9 @@ namespace xServer.Core.Packets
         {
             var type = packet.GetType();
 
+            if (client.Value == null)
+                return;
+
             if (!client.Value.IsAuthenticated)
             {
                 if (type == typeof(ClientPackets.GetAuthenticationResponse))


### PR DESCRIPTION
For some reason, killing the Client process on my VM while Remote Desktop was running on my host would cause the Server to crash.  A NullReferenceException was thrown @ Line 16 in PacketHandler.cs.  Not sure if this is the best fix, but the server is trying to handle a packet after client.Value is nulled and the check for a value in client.Value throws the exception