### PR TITLE
UPnP fix on FrmMain closing event

### DIFF
--- a/Server/Core/Helper/UPnP.cs
+++ b/Server/Core/Helper/UPnP.cs
@@ -47,11 +47,9 @@ namespace xServer.Core.Helper
                     {
                         foreach (var device in Devices)
                         {
-                            if (device.GetSpecificMapping(Protocol.Tcp, Port).PublicPort < 0) // if port is not mapped
-                            {
-                                device.CreatePortMap(new Mapping(Protocol.Tcp, Port, Port));
-                                IsPortForwarded = true;
-                            }
+                            device.GetSpecificMapping(Protocol.Tcp, Port);
+                            device.CreatePortMap(new Mapping(Protocol.Tcp, Port, Port));
+                            IsPortForwarded = true;
                         }
                     }
                     catch (MappingException)
@@ -83,11 +81,9 @@ namespace xServer.Core.Helper
         {
             foreach (var device in Devices)
             {
-                if (device.GetSpecificMapping(Protocol.Tcp, Port).PublicPort > 0) // if port map exists
-                {
-                    device.DeletePortMap(new Mapping(Protocol.Tcp, Port, Port));
-                    IsPortForwarded = false;
-                }
+                device.GetSpecificMapping(Protocol.Tcp, Port);
+                device.DeletePortMap(new Mapping(Protocol.Tcp, Port, Port));
+                IsPortForwarded = false;
             }
         }
     }


### PR DESCRIPTION
Removed condition for checking `PublicPort` property.  It doesn't appear to be reliable for determining if a port is forwarded or not.  Tested this and it had the same behavior when closing the form (Closing slower than normal) and the port was successfully removed from the UPnP list.