### PR TITLE
Remote Desktop form bug fix

### DIFF
--- a/Server/Core/Commands/SurveillanceHandler.cs
+++ b/Server/Core/Commands/SurveillanceHandler.cs
@@ -38,7 +38,7 @@ namespace xServer.Core.Commands
 
             packet.Image = null;
 
-            if (client.Value.FrmRdp != null && client.Value.FrmRdp.IsStarted)
+            if (client.Value != null && client.Value.FrmRdp != null && client.Value.FrmRdp.IsStarted)
                 new GetDesktop(packet.Quality, packet.Monitor).Execute(client);
         }
 


### PR DESCRIPTION
If a client unexpectedly disconnects from the server while rdp is running, `client.Value` can be nulled before the `SurveillanceHandler` reaches this check, causing the server to crash checking for the forms instance